### PR TITLE
Fix invalid aggregateRating placement on wedding landing page

### DIFF
--- a/bay-area-wedding-photo-booth.html
+++ b/bay-area-wedding-photo-booth.html
@@ -89,13 +89,6 @@
           "availability": "https://schema.org/InStock",
           "url": "https://handsomephotobooth.com/bay-area-wedding-photo-booth.html#pricing"
         },
-        "aggregateRating": {
-          "@type": "AggregateRating",
-          "ratingValue": "5.0",
-          "bestRating": "5",
-          "worstRating": "1",
-          "reviewCount": "100"
-        },
         "areaServed": {
           "@type": "AdministrativeArea",
           "name": "San Francisco Bay Area"


### PR DESCRIPTION
Google Rich Results flagged 'Invalid object type for field <parent_node>' on the Service block because schema.org/Service does not support star ratings as a rich-snippet eligible property. Remove the aggregateRating from the Service block. The LocalBusiness provider block still carries the same aggregateRating (5.0 / 100), which is the correct placement Google actually uses for rich snippets.