### PR TITLE
Fix blog index layout overlap and restyle header for SEO

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -245,6 +245,20 @@ header {
     -o-transition: 0.25s ease;
     transition: 0.25s ease;
 }
+main header,
+article header,
+section header,
+aside header {
+    position: static;
+    width: auto;
+    background-color: transparent;
+    z-index: auto;
+    color: inherit;
+    -webkit-transition: none;
+    -o-transition: none;
+    transition: none;
+    box-shadow: none;
+}
 header.scroll {
     background-color: #000;
     background: rgba(0, 0, 0, 0.6);
@@ -1164,6 +1178,15 @@ textarea::-webkit-input-placeholder {
     min-height: 100vh;
     background: linear-gradient(to right bottom, #d16ba5, #bd8ad2, #9fa8ee, #89c2f8, #8ad7f6, #95d9f4, #a0dcf2, #aadef0, #aed1eb, #b4c4e2, #bab8d4, #bcacc3);
 }
+.blogs-page .blogs-section {
+    padding-top: 160px;
+    padding-bottom: 80px;
+}
+.blogs-page > header,
+body.blogs-page > header {
+    background: rgba(0, 0, 0, 0.55);
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.12);
+}
 .blog-title {
     text-align: center;
 }
@@ -1197,7 +1220,7 @@ textarea::-webkit-input-placeholder {
     text-align: center;
 }
 .blogs-content {
-    padding-top: 150px;
+    padding-top: 0;
 }
 .blog-editorial {
     max-width: 1080px;
@@ -1208,29 +1231,47 @@ textarea::-webkit-input-placeholder {
     gap: 44px;
 }
 .blog-editorial-header {
+    width: min(100%, 780px);
+    margin: 0 auto;
+    padding: 0 16px;
     text-align: center;
 }
 .blog-editorial-eyebrow {
     display: inline-block;
-    padding: 6px 14px;
-    margin-bottom: 14px;
-    background: rgba(255, 255, 255, 0.85);
-    color: #0f766e;
+    padding: 9px 20px;
+    margin-bottom: 20px;
+    background: linear-gradient(90deg, #00dbde, #fc00ff);
+    color: #fff;
     font-size: 0.72rem;
     font-weight: 700;
-    letter-spacing: 0.6px;
+    letter-spacing: 1.4px;
     text-transform: uppercase;
     border-radius: 999px;
+    box-shadow: 0 8px 22px rgba(252, 0, 255, 0.28), 0 2px 6px rgba(11, 21, 53, 0.12);
 }
 .blog-editorial .blog-page-title {
-    color: #0b1535;
-    font-size: clamp(2.25rem, 5vw, 3.25rem);
-    letter-spacing: -0.04em;
+    font-size: clamp(2.2rem, 5vw, 3.4rem);
+    font-weight: 800;
+    letter-spacing: -0.035em;
+    line-height: 1.1;
+    margin-left: auto;
+    margin-right: auto;
+    background: linear-gradient(90deg, #0b1535 0%, #4f5bd5 35%, #962fbf 65%, #fc00ff 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
     text-shadow: none;
+    text-wrap: balance;
 }
 .blog-editorial .blog-page-intro {
-    margin-bottom: 0;
-    color: #2d3648;
+    margin: 18px auto 0;
+    max-width: 640px;
+    color: #1f2a44;
+    font-size: 1.08rem;
+    line-height: 1.7;
+    font-weight: 400;
+    text-wrap: pretty;
 }
 .blog-featured {
     display: grid;
@@ -1469,6 +1510,9 @@ textarea::-webkit-input-placeholder {
     box-shadow: 0 12px 24px rgba(255, 62, 165, 0.3);
 }
 @media (max-width: 960px) {
+    .blogs-page .blogs-section {
+        padding-top: 140px;
+    }
     .blog-featured {
         grid-template-columns: 1fr;
     }
@@ -1488,6 +1532,23 @@ textarea::-webkit-input-placeholder {
     }
 }
 @media (max-width: 600px) {
+    .blogs-page .blogs-section {
+        padding-top: 120px;
+    }
+    .blog-editorial {
+        gap: 28px;
+    }
+    .blog-editorial-header {
+        padding: 0 10px;
+    }
+    .blog-editorial .blog-page-title {
+        font-size: clamp(1.7rem, 9vw, 2.35rem);
+        letter-spacing: -0.025em;
+    }
+    .blog-editorial .blog-page-intro {
+        font-size: 0.92rem;
+        line-height: 1.6;
+    }
     .blog-grid {
         grid-template-columns: 1fr;
     }

--- a/blog/blog.html
+++ b/blog/blog.html
@@ -33,7 +33,7 @@
     <meta property="og:image" content="https://i.ibb.co/tzMTRrr/display.png">
     <meta property="og:image:type" content="image/png">
     <link rel="stylesheet" href="../assets/css/reset.css">
-    <link rel="stylesheet" href="../assets/css/style.css">
+    <link rel="stylesheet" href="../assets/css/style.css?v=blog-layout-20260521f">
     <link rel="stylesheet" href="../assets/css/swiper.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -128,7 +128,14 @@
         <section class="blogs-section">
             <div class="container">
                 <div class="blogs-content blog-editorial">
-                    <h1 class="visually-hidden">Bay Area Photo Booth Rental Blog</h1>
+                    <header class="blog-editorial-header">
+                        <span class="blog-editorial-eyebrow">Bay Area Photo Booth Rental Blog</span>
+                        <h1 class="blog-page-title">Bay Area Photo Booth Rental Guide for Weddings &amp; Events</h1>
+                        <p class="blog-page-intro">
+                            Expert tips on choosing a photo booth rental, planning your wedding timeline, and understanding Bay Area pricing — from a local photo booth company trusted by Bay Area couples since 2022 and named The Knot Best of Weddings 2024–2026.
+                        </p>
+                    </header>
+
                     <a href="./wedding-photo-booth-timeline.html" class="blog-featured">
                         <div class="blog-featured-img">
                             <img src="../assets/images/wedding-photo-booth-timeline.jpg" alt="Open-air wedding photo booth set up near cocktail hour at a reception" loading="lazy">

--- a/blog/blog_1.html
+++ b/blog/blog_1.html
@@ -1,186 +1,390 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6RDG7BCNMX"></script>
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-6RDG7BCNMX"
+    ></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
-
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
-
-        gtag('config', 'G-6RDG7BCNMX');
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-6RDG7BCNMX");
     </script>
-    <meta name="robots" content="index, follow">
-    <link rel="canonical" href="https://handsomephotobooth.com/blog/blog_1.html">
-    <title>Wedding Photo Booth Benefits for Bay Area Couples | Handsome Photobooth</title>
-    <meta name="description" content="See why a wedding photo booth adds guest entertainment, instant keepsakes, custom templates, and easy sharing for Bay Area weddings.">
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="keywords" content="photo booth rental,photo booth hire,wedding photo booth rental,photo booths for weddings,event photo booth,selfie booth rental,party photo booth rental,corporate photo booth,hire photo booth for party,photo booth rental bay area">
-    <link rel="icon" type="image/x-icon" href="../assets/images/favicon.png">
-    <meta property="og:url" content="https://handsomephotobooth.com/blog/blog_1.html">
-    <meta property="og:type" content="article">
-    <meta property="og:site_name" content="Handsome Photobooth">
-    <meta property="og:title" content="Wedding Photo Booth Benefits for Bay Area Couples">
-    <meta property="og:description" content="See why a wedding photo booth adds guest entertainment, instant keepsakes, custom templates, and easy sharing for Bay Area weddings.">
-    <meta property="og:image" content="https://handsomephotobooth.com/assets/images/booth.jpg">
-    <meta property="og:image:type" content="image/jpg">
-    <link rel="stylesheet" href="../assets/css/reset.css">
-    <link rel="stylesheet" href="../assets/css/style_blog.css">
-    <link rel="stylesheet" href="../assets/css/swiper.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+
+    <meta name="robots" content="index, follow" />
+    <link
+      rel="canonical"
+      href="https://handsomephotobooth.com/blog/blog_1.html"
+    />
+    <title>
+      Wedding Photo Booth Benefits for Bay Area Couples | Handsome Photobooth
+    </title>
+    <meta
+      name="description"
+      content="Why a professional open-air photo booth is essential for Bay Area weddings. Explore guest entertainment, instant high-quality keepsakes, and ice-breaking benefits."
+    />
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="keywords"
+      content="wedding photo booth benefits, photo booth rental, wedding entertainment, Bay Area wedding vendors, DSLR photo booth, instant photo prints, wedding favors"
+    />
+    <link rel="icon" type="image/x-icon" href="../assets/images/favicon.png" />
+
+    <!-- Open Graph / Social Media Preview -->
+    <meta property="og:url" content="https://handsomephotobooth.com/blog/blog_1.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="Handsome Photobooth" />
+    <meta
+      property="og:title"
+      content="Wedding Photo Booth Benefits for Bay Area Couples"
+    />
+    <meta
+      property="og:description"
+      content="Discover the real benefits of having a DSLR-quality open-air photo booth at your wedding. Keep guests entertained and create lasting keepsakes."
+    />
+    <meta
+      property="og:image"
+      content="https://handsomephotobooth.com/assets/images/booth.jpg"
+    />
+    <meta property="og:image:type" content="image/jpeg" />
+
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="../assets/css/reset.css" />
+    <link rel="stylesheet" href="../assets/css/style_blog.css" />
+    <link rel="stylesheet" href="../assets/css/swiper.css" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <!-- JSON-LD Structured Schema -->
     <script type="application/ld+json">
-        {
-            "@context": "https://schema.org",
-            "@type": "BlogPosting",
-            "headline": "Wedding Photo Booth Benefits for Bay Area Couples",
-            "description": "See why a wedding photo booth adds guest entertainment, instant keepsakes, custom templates, and easy sharing for Bay Area weddings.",
-            "image": "https://handsomephotobooth.com/assets/images/booth.jpg",
-            "datePublished": "2024-04-11",
-            "dateModified": "2024-04-11",
-            "author": {
-                "@type": "Person",
-                "name": "Leo Yeung"
-            },
-            "publisher": {
-                "@type": "Organization",
-                "name": "Handsome Photobooth",
-                "logo": {
-                    "@type": "ImageObject",
-                    "url": "https://handsomephotobooth.com/assets/images/logo.png"
-                }
-            },
-            "mainEntityOfPage": {
-                "@type": "WebPage",
-                "@id": "https://handsomephotobooth.com/blog/blog_1.html"
-            },
-            "articleSection": "Wedding Planning",
-            "inLanguage": "en-US"
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Wedding Photo Booth Benefits for Bay Area Couples",
+        "description": "Discover why an open-air DSLR photo booth is a must-have for weddings in the San Francisco Bay Area. From breaking the ice to providing premium, instant physical favors.",
+        "image": "https://handsomephotobooth.com/assets/images/booth.jpg",
+        "datePublished": "2024-04-11",
+        "dateModified": "2026-05-21",
+        "author": {
+          "@type": "Person",
+          "name": "Leo Yeung",
+          "jobTitle": "Lead Photographer & Owner",
+          "sameAs": [
+            "https://www.linkedin.com/in/leokyeung/"
+          ]
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Handsome Photobooth",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://handsomephotobooth.com/assets/images/logo.png"
+          }
+        },
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "https://handsomephotobooth.com/blog/blog_1.html"
+        },
+        "articleSection": "Wedding Planning",
+        "inLanguage": "en-US"
+      }
     </script>
-</head>
+  </head>
 
-<body class="article-page">
+  <body class="article-page">
     <div id="fb-root"></div>
     <div id="fb-customer-chat" class="fb-customerchat"></div>
     <script>
-        var chatbox = document.getElementById("fb-customer-chat");
-        chatbox.setAttribute("page_id", "102230392638740");
-        chatbox.setAttribute("attribution", "biz_inbox");
+      var chatbox = document.getElementById("fb-customer-chat");
+      chatbox.setAttribute("page_id", "102230392638740");
+      chatbox.setAttribute("attribution", "biz_inbox");
     </script>
     <script>
-        window.fbAsyncInit = function() {
-            FB.init({
-                xfbml: true,
-                version: "v15.0",
-            });
-        };
+      window.fbAsyncInit = function () {
+        FB.init({
+          xfbml: true,
+          version: "v15.0",
+        });
+      };
 
-        (function(d, s, id) {
-            var js,
-                fjs = d.getElementsByTagName(s)[0];
-            if (d.getElementById(id)) return;
-            js = d.createElement(s);
-            js.id = id;
-            js.src =
-                "https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js";
-            fjs.parentNode.insertBefore(js, fjs);
-        })(document, "script", "facebook-jssdk");
+      (function (d, s, id) {
+        var js,
+          fjs = d.getElementsByTagName(s)[0];
+        if (d.getElementById(id)) return;
+        js = d.createElement(s);
+        js.id = id;
+        js.src = "https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js";
+        fjs.parentNode.insertBefore(js, fjs);
+      })(document, "script", "facebook-jssdk");
     </script>
+
     <header>
-        <div class="nav-container">
-            <div class="container">
-                <nav> <a href="https://handsomephotobooth.com/" class="logo"> <img src="../assets/images/logo.png" alt="Handsome Photobooth"> </a> <a href="https://handsomephotobooth.com/#contact" class="btn_top">Contact Us</a>
-                    <ul class="nav-list">
-                        <li> <a href="https://handsomephotobooth.com/#about" class="nav-link">About Us</a> </li>
-                        <li> <a href="https://handsomephotobooth.com/#pricing" class="nav-link">Package & Equipment</a> </li>
-                        <li> <a href="https://handsomephotobooth.com/#contact" class="nav-link">Contact Us</a> </li>
-                        <li> <a href="https://handsomephotobooth.com/blog/blog.html" class="nav-link">Blog</a> </li>
-                    </ul>
-                    <div class="hamburger"> <span></span> <span></span> <span></span> <span></span> </div>
-                </nav>
-            </div>
-        </div>
-    </header>
-    <main>
-        <section class="hero-section" id="home">
-            <div class="container">
-                <div class="hero-content"> <a href="https://handsomephotobooth.com/blog/blog.html">Back To Home</a>
-                    <h1>Why a Photo Booth Is a Must-Have for Your Wedding</h1>
-                </div>
-            </div>
-        </section>
-        <section class="article-section">
-            <div class="container">
-                <div class="article-content">
-                    <div class="article-img"> <img src="../assets/images/booth.jpg" style="width:80%; margin-left: auto; margin-right: auto" alt="Open-air wedding photo booth with professional lighting and backdrop"> </div>
-                    <article>
-                        <p> Are you planning your wedding and looking for a unique way to capture memories? Consider adding a photo booth from our photo booth business to your special day! Here are four reasons why a photo booth is a fun and memorable addition
-                            to weddings.</p>
-                        <h2>Create Lasting Memories with High-Quality Prints</h2>
-                        <p>Our photo booth is equipped with a DSLR camera, which ensures high-quality prints that you and your guests will cherish for years to come. You can choose between 2x6 (strip) or 4x6 prints, and we fully customize the photo booth
-                            template to fit your wedding's aesthetic. Plus, our modern backdrop and unique props will help your guests create one-of-a-kind memories.</p>
-                        <h2>Keep Your Guests Entertained with Interactive Fun</h2>
-                        <p> A photo booth is a great way to keep your guests entertained during the reception. They can take turns posing for photos, trying out different props, and getting creative with their shots. Our instant digital copy delivery to email
-                            and downloadable album on Google Photos means that guests can easily access their photos, even after the event is over. Plus, our professional booth attendant is there to assist guests and ensure that everyone has a great time.
-                            </p>
-                        <h2>Customize the Photo Booth to Fit Your Wedding Style</h2>
-                        <p> Our photo booth is fully customizable, allowing you to tailor it to fit the theme and style of your wedding. With a range of backdrops to choose from and professional studio lighting, we can create a photo booth that complements
-                            your overall wedding aesthetic. </p>
-                        <h2>Encourage Social Media Engagement with Easy Sharing</h2>
-                        <p> In today's digital age, social media is a great way to share memories with friends and family who couldn't attend your wedding. Our photo booth allows your guests to take and share photos on social media, spreading the word about
-                            your wedding to a wider audience. You can even create a contest or giveaway around the photos, encouraging your guests to share and engage with your wedding even after the event is over. </p>
-                        <br>
-                            <p> By adding a photo booth from our photo booth business to your wedding, you're not only creating fun memories for you and your guests, but you're also adding a unique element to your special day. So why wait? <a class="blog-link"
-                                    href="https://handsomephotobooth.com/#contact">Book our photo booth</a> for your wedding today and create memories that will last a lifetime! </p>
-                            <p>Want the full wedding package details? See our <a class="blog-link" href="https://handsomephotobooth.com/bay-area-wedding-photo-booth.html">Bay Area wedding photo booth rental</a> page.</p>
-                    </article>
-                </div>
-            </div>
-        </section>
-    </main>
-    <footer>
+      <div class="nav-container">
         <div class="container">
-            <div class="footer-content">
-                <div class="footer-nav">
-                    <div>
-                        <h5 class="gradient">Follow Us!</h5>
-                        <ul class="social-list">
-                            <li>
-                                <a href="https://www.instagram.com/handsomephotobooth/" target="_blank" rel="noopener noreferrer" aria-label="Follow Handsome Photobooth on Instagram">
-                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
-                                        <defs>
-                                            <linearGradient id="instagram-gradient" x1="0%" y1="100%" x2="100%" y2="0%">
-                                                <stop offset="0%" style="stop-color:#feda75;stop-opacity:1" />
-                                                <stop offset="25%" style="stop-color:#fa7e1e;stop-opacity:1" />
-                                                <stop offset="50%" style="stop-color:#d62976;stop-opacity:1" />
-                                                <stop offset="75%" style="stop-color:#962fbf;stop-opacity:1" />
-                                                <stop offset="100%" style="stop-color:#4f5bd5;stop-opacity:1" />
-                                            </linearGradient>
-                                        </defs>
-                                        <path fill="url(#instagram-gradient)" d="M9.9980469 3C6.1390469 3 3 6.1419531 3 10.001953L3 20.001953C3 23.860953 6.1419531 27 10.001953 27L20.001953 27C23.860953 27 27 23.858047 27 19.998047L27 9.9980469C27 6.1390469 23.858047 3 19.998047 3L9.9980469 3 z M 22 7C22.552 7 23 7.448 23 8C23 8.552 22.552 9 22 9C21.448 9 21 8.552 21 8C21 7.448 21.448 7 22 7 z M 15 9C18.309 9 21 11.691 21 15C21 18.309 18.309 21 15 21C11.691 21 9 18.309 9 15C9 11.691 11.691 9 15 9 z M 15 11 A 4 4 0 0 0 11 15 A 4 4 0 0 0 15 19 A 4 4 0 0 0 19 15 A 4 4 0 0 0 15 11 z" />
-                                    </svg>
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="copyright">
-                    <p> © Copyright 2026 Handsome Photobooth | All Rights Reserved </p>
-                </div>
+          <nav>
+            <a href="https://handsomephotobooth.com/" class="logo">
+              <img
+                src="../assets/images/logo.png"
+                alt="Handsome Photobooth Logo"
+              />
+            </a>
+            <a href="https://handsomephotobooth.com/#contact" class="btn_top"
+              >Contact Us</a
+            >
+            <ul class="nav-list">
+              <li>
+                <a href="https://handsomephotobooth.com/#about" class="nav-link"
+                  >About Us</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/#pricing"
+                  class="nav-link"
+                  >Package & Equipment</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/#contact"
+                  class="nav-link"
+                  >Contact Us</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/blog/blog.html"
+                  class="nav-link"
+                  >Blog</a
+                >
+              </li>
+            </ul>
+            <div class="hamburger">
+              <span></span>
+              <span></span>
+              <span></span>
+              <span></span>
             </div>
+          </nav>
         </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero-section" id="home">
+        <div class="container">
+          <div class="hero-content">
+            <a href="https://handsomephotobooth.com/blog/blog.html"
+              >Back To Blog</a
+            >
+            <h1>Why a Photo Booth Is a Must-Have for Your Wedding</h1>
+          </div>
+        </div>
+      </section>
+
+      <section class="article-section">
+        <div class="container">
+          <div class="article-content">
+            <div class="article-img">
+              <img
+                src="../assets/images/booth.jpg"
+                style="width: 80%; margin-left: auto; margin-right: auto"
+                alt="Open-air wedding photo booth setup with studio lighting and a clean backdrop"
+              />
+            </div>
+            <article>
+              <p>
+                Planning your dream wedding in the San Francisco Bay Area is a journey 
+                filled with design choices, venue walkthroughs, and tasting sessions. 
+                But above all, couples want their wedding to feel like an inclusive, joyful 
+                celebration where guests let loose and build lifelong memories.
+              </p>
+              <p>
+                While your wedding photographer captures the formal timeline, there is 
+                one feature that consistently keeps guests laughing and provides instant 
+                favor keepsakes: a professional open-air photo booth. 
+              </p>
+              <p>
+                Here are the four leading reasons why an open-air, DSLR-powered photo booth 
+                is an essential, high-value asset for modern weddings.
+              </p>
+
+              <h2>1. The Ultimate Icebreaker for Multi-Generational Guests</h2>
+              <p>
+                Weddings bring together families, high school friends, college roommates, and 
+                coworkers—many of whom have never met before. Cocktail hour and early reception 
+                can sometimes feel slightly formal as groups mingle. 
+              </p>
+              <p>
+                A photo booth is the ultimate social icebreaker. There is something magical 
+                about putting on a ridiculous pair of giant sunglasses or holding a witty sign 
+                that instantly melts away social barriers. It encourages your college friends 
+                to strike poses with your grandparents, creating lighthearted interactions 
+                that carry over onto the dance floor. 
+              </p>
+
+              <h2>2. Premium, Customized Keepsakes (The Perfect Favor)</h2>
+              <p>
+                Many traditional wedding favors—like custom matches, personalized mints, or 
+                packaged sweets—are often left behind on the tables or thrown away. 
+              </p>
+              <p>
+                A photo strip is a personalized, physical favor that guests actively treasure. 
+                By utilizing a professional dye-sublimation printer, a high-quality photo booth 
+                delivers lab-grade, completely waterproof, and dry physical prints in under 15 seconds. 
+                Whether it is a classic 2x6 strip or a premium 4x6 print, guests put them on 
+                their refrigerators, frame them on their office desks, and look back at them for years. 
+                Best of all, you can have a matching scrapbook on-site where guests slide in a copy of 
+                their print and write a handwritten message, creating a physical guestbook that you'll 
+                cherish forever.
+              </p>
+
+              <h2>3. Beautiful, Studio-Quality Portraits of Your Guests</h2>
+              <p>
+                Your primary wedding photographer is incredibly busy focusing on you—the couple. 
+                They are capturing the walk down the aisle, the first kiss, the formal portraits, 
+                and the speeches. They simply don't have the time to take high-quality portraits 
+                of all your 100+ guests.
+              </p>
+              <p>
+                An open-air booth equipped with a professional DSLR camera and a studio strobe 
+                flash acts as a secondary mini-portrait studio. It captures your guests looking 
+                their absolute best under professional lighting. Weeks after the wedding, when 
+                you receive the downloadable Google Photos digital gallery, you will have a gorgeous 
+                archive of every friend, relative, and family member smiling, laughing, and 
+                celebrating your day.
+              </p>
+
+              <h2>4. Interactive Entertainment During Natural "Downtime"</h2>
+              <p>
+                Even the most meticulously planned weddings have natural transitional periods. 
+                During room turnovers, while you are taking sunset portraits, or during the early 
+                stages of dancing, some guests aren't ready to dance but want to remain active. 
+              </p>
+              <p>
+                An open-air photo booth serves as a primary hub of interactive entertainment. 
+                It gives non-dancers a fun activity to engage in and ensures your reception remains 
+                dynamic and energetic from the start of cocktail hour to the final send-off. With 
+                instant QR code downloads, guests can save the digital files directly to their 
+                phones to share on social media immediately, building excitement in real-time.
+              </p>
+
+              <h2>Planning Your Wedding & Ready to Choose a Vendor?</h2>
+              <p>
+                To make sure your photo booth fits seamlessly into your big day without any 
+                added stress, keep these essential planning tips in mind:
+              </p>
+              <ul>
+                <li>
+                  <strong>Check your timeline:</strong> Learn when the best time is to keep the booth active in our 
+                  <a href="./wedding-photo-booth-timeline.html" style="color: #ff6b6b; font-weight: 600; text-decoration: underline;">Wedding Photo Booth Timeline Guide</a>.
+                </li>
+                <li>
+                  <strong>Compare technical specs:</strong> Ensure your vendor uses high-quality cameras and lights by reading our checklist on 
+                  <a href="./blog_2.html" style="color: #ff6b6b; font-weight: 600; text-decoration: underline;">How to Choose a Bay Area Photo Booth Vendor</a>.
+                </li>
+                <li>
+                  <strong>Analyze your budget:</strong> See exactly what standard rentals cost in our comprehensive 
+                  <a href="./blog_3.html" style="color: #ff6b6b; font-weight: 600; text-decoration: underline;">Bay Area Wedding Photo Booth Cost Guide</a>.
+                </li>
+              </ul>
+
+              <p style="text-align: center; margin-top: 40px; font-style: italic;">
+                At Handsome Photobooth, we offer an all-inclusive 3-hour Glam Package 
+                featuring professional DSLR portraits, unlimited lab-quality prints, 
+                over 70 premium props, and custom-designed templates that match your 
+                wedding invitations perfectly.
+              </p>
+
+              <p style="text-align: center; margin-top: 20px;">
+                Explore our full 
+                <a class="blog-link" href="https://handsomephotobooth.com/bay-area-wedding-photo-booth.html" style="font-weight: 700; color: #ff6b6b;">Bay Area Wedding Photo Booth Rental</a> 
+                package, and 
+                <a class="blog-link" href="https://handsomephotobooth.com/#contact" style="font-weight: 700; color: #ff6b6b;">check our availability</a> for your date!
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container">
+        <div class="footer-content">
+          <div class="footer-nav">
+            <div>
+              <h5 class="gradient">Follow Us!</h5>
+              <ul class="social-list">
+                <li>
+                  <a
+                    href="https://www.instagram.com/handsomephotobooth/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Follow Handsome Photobooth on Instagram"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+                      <defs>
+                        <linearGradient
+                          id="instagram-gradient"
+                          x1="0%"
+                          y1="100%"
+                          x2="100%"
+                          y2="0%"
+                        >
+                          <stop
+                            offset="0%"
+                            style="stop-color: #feda75; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="25%"
+                            style="stop-color: #fa7e1e; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="50%"
+                            style="stop-color: #d62976; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="75%"
+                            style="stop-color: #962fbf; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="100%"
+                            style="stop-color: #4f5bd5; stop-opacity: 1"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <path
+                        fill="url(#instagram-gradient)"
+                        d="M9.9980469 3C6.1390469 3 3 6.1419531 3 10.001953L3 20.001953C3 23.860953 6.1419531 27 10.001953 27L20.001953 27C23.860953 27 27 23.858047 27 19.998047L27 9.9980469C27 6.1390469 23.858047 3 19.998047 3L9.9980469 3 z M 22 7C22.552 7 23 7.448 23 8C23 8.552 22.552 9 22 9C21.448 9 21 8.552 21 8C21 7.448 21.448 7 22 7 z M 15 9C18.309 9 21 11.691 21 15C21 18.309 18.309 21 15 21C11.691 21 9 18.309 9 15C9 11.691 11.691 9 15 9 z M 15 11 A 4 4 0 0 0 11 15 A 4 4 0 0 0 15 19 A 4 4 0 0 0 19 15 A 4 4 0 0 0 15 11 z"
+                      />
+                    </svg>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="copyright">
+            <p>© Copyright 2026 Handsome Photobooth | All Rights Reserved</p>
+          </div>
+        </div>
+      </div>
     </footer>
+
     <script src="../assets/js/swiper.js"></script>
     <script src="../assets/js/script.js"></script>
     <script src="../assets/js/fslightbox.js"></script>
     <script src="../assets/js/share.js"></script>
-</body>
-
+  </body>
 </html>

--- a/blog/blog_2.html
+++ b/blog/blog_2.html
@@ -1,90 +1,399 @@
-<!DOCTYPE html><html lang="en"><head><script async src="https://www.googletagmanager.com/gtag/js?id=G-6RDG7BCNMX"></script> <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-6RDG7BCNMX"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
         dataLayer.push(arguments);
-    }
-    gtag('js', new Date());
+      }
+      gtag("js", new Date());
+      gtag("config", "G-6RDG7BCNMX");
+    </script>
 
-    gtag('config', 'G-6RDG7BCNMX');
-</script> <meta name="robots" content="index, follow"><link rel="canonical" href="https://handsomephotobooth.com/blog/blog_2.html"><title>How to Choose a Bay Area Photo Booth Vendor | Handsome Photobooth</title><meta name="description" content="Use this Bay Area checklist to compare photo booth vendors by experience, photo quality, printing, templates, pricing, service, and reliability."><meta charset="UTF-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"><meta name="viewport" content="width=device-width, initial-scale=1.0"><meta name="keywords" content="photo booth rental,photo booth hire,wedding photo booth rental,photo booths for weddings,event photo booth,selfie booth rental,party photo booth rental,corporate photo booth,hire photo booth for party,photo booth rental bay area"><link rel="icon" type="image/x-icon" href="../assets/images/favicon.png"><meta property="og:url" content="https://handsomephotobooth.com/blog/blog_2.html"><meta property="og:type" content="article"><meta property="og:site_name" content="Handsome Photobooth"><meta property="og:title" content="How to Choose a Bay Area Photo Booth Vendor"><meta property="og:description" content="Use this Bay Area checklist to compare photo booth vendors by experience, photo quality, printing, templates, pricing, service, and reliability."><meta property="og:image" content="https://handsomephotobooth.com/assets/images/planning.jpg"><meta property="og:image:type" content="image/jpg"><link rel="stylesheet" href="../assets/css/reset.css"><link rel="stylesheet" href="../assets/css/style_blog.css"><link rel="stylesheet" href="../assets/css/swiper.css"><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet"><script type="application/ld+json">
-    {
+    <meta name="robots" content="index, follow" />
+    <link
+      rel="canonical"
+      href="https://handsomephotobooth.com/blog/blog_2.html"
+    />
+    <title>
+      How to Choose a Bay Area Photo Booth Vendor | Handsome Photobooth
+    </title>
+    <meta
+      name="description"
+      content="The ultimate Bay Area photo booth rental guide. Compare DSLR quality, studio lighting, dye-sub prints, templates, pricing, and backup plans before booking."
+    />
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="keywords"
+      content="photo booth rental, photo booth hire, wedding photo booth rental, photo booths for weddings, event photo booth, selfie booth rental, party photo booth rental, corporate photo booth, photo booth rental bay area, DSLR photo booth, studio quality photo booth"
+    />
+    <link rel="icon" type="image/x-icon" href="../assets/images/favicon.png" />
+
+    <!-- Open Graph / Social Media Preview -->
+    <meta property="og:url" content="https://handsomephotobooth.com/blog/blog_2.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="Handsome Photobooth" />
+    <meta
+      property="og:title"
+      content="How to Choose a Bay Area Photo Booth Vendor | Ultimate Checklist"
+    />
+    <meta
+      property="og:description"
+      content="Compare DSLR quality, professional studio lighting, custom template designs, and pricing before booking a photo booth for your wedding or event."
+    />
+    <meta
+      property="og:image"
+      content="https://handsomephotobooth.com/assets/images/planning.jpg"
+    />
+    <meta property="og:image:type" content="image/jpeg" />
+
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="../assets/css/reset.css" />
+    <link rel="stylesheet" href="../assets/css/style_blog.css" />
+    <link rel="stylesheet" href="../assets/css/swiper.css" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <!-- JSON-LD Structured Schema -->
+    <script type="application/ld+json">
+      {
         "@context": "https://schema.org",
         "@type": "BlogPosting",
         "headline": "How to Choose a Bay Area Photo Booth Vendor",
-        "description": "Use this Bay Area checklist to compare photo booth vendors by experience, photo quality, printing, templates, pricing, service, and reliability.",
+        "description": "Compare DSLR camera quality, studio-grade lighting, instant prints, custom template designs, backup equipment, and pricing transparency before you book a photo booth for your Bay Area wedding or event.",
         "image": "https://handsomephotobooth.com/assets/images/planning.jpg",
         "datePublished": "2024-04-15",
-        "dateModified": "2024-04-15",
+        "dateModified": "2026-05-21",
         "author": {
-            "@type": "Person",
-            "name": "Leo Yeung"
+          "@type": "Person",
+          "name": "Leo Yeung",
+          "jobTitle": "Lead Photographer & Owner",
+          "sameAs": [
+            "https://www.linkedin.com/in/leokyeung/"
+          ]
         },
         "publisher": {
-            "@type": "Organization",
-            "name": "Handsome Photobooth",
-            "logo": {
-                "@type": "ImageObject",
-                "url": "https://handsomephotobooth.com/assets/images/logo.png"
-            }
+          "@type": "Organization",
+          "name": "Handsome Photobooth",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://handsomephotobooth.com/assets/images/logo.png"
+          }
         },
         "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://handsomephotobooth.com/blog/blog_2.html"
+          "@type": "WebPage",
+          "@id": "https://handsomephotobooth.com/blog/blog_2.html"
         },
         "articleSection": "Event Planning",
         "inLanguage": "en-US"
-    }
-</script> </head> <body class="article-page"><div id="fb-root"></div> <div id="fb-customer-chat" class="fb-customerchat"></div> <script>
-    var chatbox = document.getElementById("fb-customer-chat");
-    chatbox.setAttribute("page_id", "102230392638740");
-    chatbox.setAttribute("attribution", "biz_inbox");
-</script> <script>
-    window.fbAsyncInit = function () {
-        FB.init({
-            xfbml: true,
-            version: "v15.0",
-        });
-    };
+      }
+    </script>
+  </head>
 
-    (function (d, s, id) {
+  <body class="article-page">
+    <div id="fb-root"></div>
+    <div id="fb-customer-chat" class="fb-customerchat"></div>
+    <script>
+      var chatbox = document.getElementById("fb-customer-chat");
+      chatbox.setAttribute("page_id", "102230392638740");
+      chatbox.setAttribute("attribution", "biz_inbox");
+    </script>
+    <script>
+      window.fbAsyncInit = function () {
+        FB.init({
+          xfbml: true,
+          version: "v15.0",
+        });
+      };
+
+      (function (d, s, id) {
         var js,
-            fjs = d.getElementsByTagName(s)[0];
+          fjs = d.getElementsByTagName(s)[0];
         if (d.getElementById(id)) return;
         js = d.createElement(s);
         js.id = id;
-        js.src =
-            "https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js";
+        js.src = "https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js";
         fjs.parentNode.insertBefore(js, fjs);
-    })(document, "script", "facebook-jssdk");
-</script> <header> <div class="nav-container"> <div class="container"> <nav> <a href="https://handsomephotobooth.com/" class="logo"> <img src="../assets/images/logo.png" alt="Handsome Photobooth"> </a> <a href="https://handsomephotobooth.com/#contact" class="btn_top">Contact Us</a> <ul class="nav-list"> <li> <a href="https://handsomephotobooth.com/#about" class="nav-link">About Us</a> </li> <li> <a href="https://handsomephotobooth.com/#pricing" class="nav-link">Package & Equipment</a> </li> <li> <a href="https://handsomephotobooth.com/#contact" class="nav-link">Contact Us</a> </li> <li> <a href="https://handsomephotobooth.com/blog/blog.html" class="nav-link">Blog</a> </li> </ul> <div class="hamburger"> <span></span> <span></span> <span></span> <span></span> </div> </nav> </div> </div> </header> <main> <section class="hero-section" id="home"> <div class="container"> <div class="hero-content"> <a href="https://handsomephotobooth.com/blog/blog.html">Back To Home</a> <h1> How to Choose a Bay Area Photo Booth Vendor </h1> </div> </div> </section> <section class="article-section"> <div class="container"> <div class="article-content"> <div class="article-img"> <img src="../assets/images/planning.jpg" style="width:70%; margin-left: auto; margin-right: auto" alt="Woman is considering how to choose the best photo booth vendor for her event"> </div> <article> <p>Planning a wedding, party, or company event in the Bay Area and comparing photo booth vendors? Use this checklist to evaluate photo quality, service, customization, reliability, and pricing before you book. </p> <h2>Look for Bay Area event experience and responsive service</h2> <p>When looking for a photo booth vendor, it's important to find one that has experience in providing services for events like yours. This will ensure that they know what to expect and can anticipate any potential issues that may arise. Additionally, you should look for a vendor that has a reputation for providing excellent customer service. They should always be responsive to your questions and concerns and should be willing to work with you to customize their services to fit your specific needs. Good customer service can make a big difference in your overall experience and satisfaction with the vendor, so it's important to prioritize this factor in your decision-making process. </p> <h2>Review their photo booth portfolio and sample galleries</h2> <p> Before hiring a photo booth vendor, be sure to check out their portfolio. This will give you an idea of the quality of their work and the types of events they have worked on in the past. You can also ask for references from past clients to get an idea of their experience working with the vendor. </p> <h2>Compare camera, lighting, and print quality</h2> <p> Another important factor to consider is the equipment the vendor uses. A professional photo booth vendor will use high-quality equipment such as a DSLR camera and professional studio lighting. They should also offer different printing options such as 2x6 (strip) or 4x6 prints to cater to your event needs. </p> <h2>Ask about templates, backdrops, props, and sharing options</h2> <p> Many photo booth vendors offer a variety of customization options to make your event unique and memorable. Some popular options include customized photo templates, unique backdrops, and personalized props. However, it's also important to consider more advanced customization options, such as video messaging. With video messaging, guests can leave short video messages that can be compiled into a digital guestbook or shared on social media. This can be a fun and interactive way to capture memories and add a personal touch to your event. </p> <h2>Confirm availability, setup timing, and backup plans</h2> <p> Be sure to check the availability of the photo booth vendor before making a final decision. Popular vendors tend to book up quickly, so it's important to book in advance. Additionally, ensure the vendor has a contingency plan in case of unforeseen circumstances such as equipment failure or illness of the booth attendant. </p> <h2>Review the contract, pricing, and add-on fees</h2> <p> Before signing a contract, review it carefully and ensure it covers everything you have agreed upon. Check for additional fees such as travel and setup fees that may not be included in the initial pricing. Ensure there are no hidden costs and the pricing is transparent. </p> <p> By considering these factors when choosing a photo booth vendor, you can ensure that your event is a success and your guests have a great time. </p> <p>Planning a Bay Area wedding? See our dedicated <a class="blog-link" href="https://handsomephotobooth.com/bay-area-wedding-photo-booth.html">Bay Area wedding photo booth rental</a> page for pricing, what is included, and real wedding reviews.</p> </article> </div> </div> </section> </main> <footer>
+      })(document, "script", "facebook-jssdk");
+    </script>
+
+    <header>
+      <div class="nav-container">
         <div class="container">
-            <div class="footer-content">
-                <div class="footer-nav">
-                    <div>
-                        <h5 class="gradient">Follow Us!</h5>
-                        <ul class="social-list">
-                            <li>
-                                <a href="https://www.instagram.com/handsomephotobooth/" target="_blank" rel="noopener noreferrer" aria-label="Follow Handsome Photobooth on Instagram">
-                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
-                                        <defs>
-                                            <linearGradient id="instagram-gradient" x1="0%" y1="100%" x2="100%" y2="0%">
-                                                <stop offset="0%" style="stop-color:#feda75;stop-opacity:1" />
-                                                <stop offset="25%" style="stop-color:#fa7e1e;stop-opacity:1" />
-                                                <stop offset="50%" style="stop-color:#d62976;stop-opacity:1" />
-                                                <stop offset="75%" style="stop-color:#962fbf;stop-opacity:1" />
-                                                <stop offset="100%" style="stop-color:#4f5bd5;stop-opacity:1" />
-                                            </linearGradient>
-                                        </defs>
-                                        <path fill="url(#instagram-gradient)" d="M9.9980469 3C6.1390469 3 3 6.1419531 3 10.001953L3 20.001953C3 23.860953 6.1419531 27 10.001953 27L20.001953 27C23.860953 27 27 23.858047 27 19.998047L27 9.9980469C27 6.1390469 23.858047 3 19.998047 3L9.9980469 3 z M 22 7C22.552 7 23 7.448 23 8C23 8.552 22.552 9 22 9C21.448 9 21 8.552 21 8C21 7.448 21.448 7 22 7 z M 15 9C18.309 9 21 11.691 21 15C21 18.309 18.309 21 15 21C11.691 21 9 18.309 9 15C9 11.691 11.691 9 15 9 z M 15 11 A 4 4 0 0 0 11 15 A 4 4 0 0 0 15 19 A 4 4 0 0 0 19 15 A 4 4 0 0 0 15 11 z" />
-                                    </svg>
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="copyright">
-                    <p> © Copyright 2026 Handsome Photobooth | All Rights Reserved </p>
-                </div>
+          <nav>
+            <a href="https://handsomephotobooth.com/" class="logo">
+              <img
+                src="../assets/images/logo.png"
+                alt="Handsome Photobooth Logo"
+              />
+            </a>
+            <a href="https://handsomephotobooth.com/#contact" class="btn_top"
+              >Contact Us</a
+            >
+            <ul class="nav-list">
+              <li>
+                <a href="https://handsomephotobooth.com/#about" class="nav-link"
+                  >About Us</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/#pricing"
+                  class="nav-link"
+                  >Package & Equipment</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/#contact"
+                  class="nav-link"
+                  >Contact Us</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/blog/blog.html"
+                  class="nav-link"
+                  >Blog</a
+                >
+              </li>
+            </ul>
+            <div class="hamburger">
+              <span></span>
+              <span></span>
+              <span></span>
+              <span></span>
             </div>
+          </nav>
         </div>
-    </footer> <script src="../assets/js/swiper.js"></script> <script src="../assets/js/script.js"></script> <script src="../assets/js/fslightbox.js"></script> <script src="../assets/js/share.js"></script> </body></html>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero-section" id="home">
+        <div class="container">
+          <div class="hero-content">
+            <a href="https://handsomephotobooth.com/blog/blog.html"
+              >Back To Blog</a
+            >
+            <h1>How to Choose a Bay Area Photo Booth Vendor</h1>
+          </div>
+        </div>
+      </section>
+
+      <section class="article-section">
+        <div class="container">
+          <div class="article-content">
+            <div class="article-img">
+              <img
+                src="../assets/images/planning.jpg"
+                style="width: 70%; margin-left: auto; margin-right: auto"
+                alt="Event planner comparing Bay Area photo booth vendors on a laptop"
+              />
+            </div>
+            <article>
+              <p>
+                Planning a wedding, corporate event, or milestone birthday in
+                the San Francisco Bay Area? Comparing photo booth vendors can quickly
+                become overwhelming. With dozens of options ranging from cheap,
+                self-service iPads to high-end, studio-grade setups, the difference 
+                in final results can be night and day. 
+              </p>
+              <p>
+                Use this comprehensive industry checklist to evaluate photo quality, 
+                equipment specs, print technology, custom designs, backup reliability, 
+                and pricing so you can book with complete confidence.
+              </p>
+
+              <h2>1. Camera Quality: Professional DSLR vs. Cheap iPad / Webcams</h2>
+              <p>
+                The camera is the heart of any photo booth. Many budget-friendly vendors 
+                use standard iPads, tablets, or generic webcams. While they are easy to 
+                transport, their small image sensors struggle immensely in low-light environments, 
+                such as dimmed wedding reception halls or evening corporate galas. 
+              </p>
+              <p>
+                <strong>What to look for:</strong> Ask if the booth uses a professional 
+                <strong>DSLR or mirrorless camera</strong> (such as a Canon, Nikon, or Sony). 
+                A true camera captures razor-sharp details, accurate skin tones, and rich colors, 
+                meaning your prints and digital files will look like professional studio portraits 
+                rather than grainy smartphone selfies.
+              </p>
+
+              <h2>2. Lighting Setup: Studio-Grade Flash vs. Basic Ring Lights</h2>
+              <p>
+                Even the most expensive camera will produce poor photos without good lighting. 
+                Many selfie booths rely solely on a small, circular LED ring light. While ring 
+                lights are decent for up-close social media videos, they cast harsh shadows on 
+                larger groups, exaggerate skin blemishes, and cause distracting "red-eye."
+              </p>
+              <p>
+                <strong>What to look for:</strong> Choose a vendor that utilizes a 
+                <strong>studio-grade external strobe (flash)</strong> paired with a professional 
+                diffuser (like an umbrella or beauty dish). This setup bounces soft, even light 
+                across the entire group, smoothing skin tones and creating a highly flattering, 
+                glamorous look that makes everyone look their absolute best.
+              </p>
+
+              <h2>3. Printing Technology: Instant Dye-Sublimation vs. Slow Inkjets</h2>
+              <p>
+                If your package includes physical prints, the technology matters. Lower-end 
+                booths sometimes use consumer inkjet printers. These printers are incredibly 
+                slow (taking up to a minute per print), causing long lines to form, and the 
+                prints can smudge easily if touched immediately.
+              </p>
+              <p>
+                <strong>What to look for:</strong> Ensure your vendor uses a professional 
+                <strong>dye-sublimation printer</strong>. These commercial-grade machines 
+                print lab-quality, waterproof, and completely dry-to-the-touch prints in less 
+                than 15 seconds. This keeps the photo booth line moving rapidly and ensures 
+                guests walk away with a premium keepsake that won't fade or bleed.
+              </p>
+
+              <h2>4. Graphic Customization: Bespoke Layouts vs. Generic Templates</h2>
+              <p>
+                Your photo print is a direct reflection of your event's theme. Many vendors use 
+                the basic templates that come pre-packaged with their photo booth software, 
+                resulting in generic borders and uninspired fonts that might clash with your style.
+              </p>
+              <p>
+                <strong>What to look for:</strong> Ask if their package includes a 
+                <strong>custom design service</strong> from a graphic designer. A professional 
+                vendor will collaborate with you to incorporate your exact colors, custom typography, 
+                monograms, wedding florals, or company logos so the final photo strip perfectly 
+                matches your wedding invitations or corporate branding.
+              </p>
+
+              <h2>5. Redundancy & Reliability: Backup Equipment and Attendants</h2>
+              <p>
+                Live events are unpredictable. Cameras can overheat, printer paper can jam, 
+                and cables can fail. If a vendor has no backup equipment on-site, a minor 
+                technical hiccup can completely ruin your photo booth experience for the night.
+              </p>
+              <p>
+                <strong>What to look for:</strong> Always ask the vendor about their redundancy plans. 
+                Do they bring backup cameras, printers, and critical cords to every event? 
+                Additionally, confirm if a <strong>professional on-site attendant</strong> is included. 
+                An active, friendly attendant doesn't just troubleshoot tech issues in seconds—they also 
+                keep the props organized, assist older guests, suggest fun poses, and manage lines 
+                to ensure a seamless flow.
+              </p>
+
+              <h2>6. Transparent Pricing: All-Inclusive vs. Hidden Add-on Fees</h2>
+              <p>
+                Many "cheap" initial quotes end up being more expensive after adding critical 
+                basics. Some vendors lure you in with a low base price, only to tack on hefty 
+                fees for travel within the Bay Area, template customization, digital sharing, backdrop 
+                use, or booth setup and breakdown times.
+              </p>
+              <p>
+                <strong>What to look for:</strong> Look for a vendor with highly transparent, 
+                <strong>all-inclusive pricing</strong>. Setup and teardown time should always 
+                be included in the vendor's own prep time, not deducted from your operating hours. 
+                Make sure the contract explicitly outlines travel boundaries, idle hours, and 
+                any potential taxes or service fees before signing. Learn more about average local rates in our 
+                <a href="./blog_3.html" style="color: #ff6b6b; font-weight: 600; text-decoration: underline;">Bay Area Wedding Photo Booth Cost Guide</a>.
+              </p>
+
+              <hr style="border: 0; border-top: 1px solid #eaeef6; margin: 40px 0;" />
+
+              <p style="text-align: center; font-style: italic;">
+                Planning a Bay Area wedding or event and want a studio-quality experience? 
+                At Handsome Photobooth, we use high-end DSLR cameras, professional studio flash 
+                umbrellas, commercial dye-sub printers, and custom graphic layouts to make your 
+                guests look absolutely stunning.
+              </p>
+
+              <p style="text-align: center; margin-top: 20px;">
+                Learn more about our fully-inclusive 
+                <a class="blog-link" href="https://handsomephotobooth.com/bay-area-wedding-photo-booth.html" style="font-weight: 700; color: #ff6b6b;">Bay Area Wedding Photo Booth Rental</a> 
+                package, view real event galleries, and 
+                <a class="blog-link" href="https://handsomephotobooth.com/#contact" style="font-weight: 700; color: #ff6b6b;">book your date</a> today!
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container">
+        <div class="footer-content">
+          <div class="footer-nav">
+            <div>
+              <h5 class="gradient">Follow Us!</h5>
+              <ul class="social-list">
+                <li>
+                  <a
+                    href="https://www.instagram.com/handsomephotobooth/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Follow Handsome Photobooth on Instagram"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+                      <defs>
+                        <linearGradient
+                          id="instagram-gradient"
+                          x1="0%"
+                          y1="100%"
+                          x2="100%"
+                          y2="0%"
+                        >
+                          <stop
+                            offset="0%"
+                            style="stop-color: #feda75; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="25%"
+                            style="stop-color: #fa7e1e; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="50%"
+                            style="stop-color: #d62976; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="75%"
+                            style="stop-color: #962fbf; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="100%"
+                            style="stop-color: #4f5bd5; stop-opacity: 1"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <path
+                        fill="url(#instagram-gradient)"
+                        d="M9.9980469 3C6.1390469 3 3 6.1419531 3 10.001953L3 20.001953C3 23.860953 6.1419531 27 10.001953 27L20.001953 27C23.860953 27 27 23.858047 27 19.998047L27 9.9980469C27 6.1390469 23.858047 3 19.998047 3L9.9980469 3 z M 22 7C22.552 7 23 7.448 23 8C23 8.552 22.552 9 22 9C21.448 9 21 8.552 21 8C21 7.448 21.448 7 22 7 z M 15 9C18.309 9 21 11.691 21 15C21 18.309 18.309 21 15 21C11.691 21 9 18.309 9 15C9 11.691 11.691 9 15 9 z M 15 11 A 4 4 0 0 0 11 15 A 4 4 0 0 0 15 19 A 4 4 0 0 0 19 15 A 4 4 0 0 0 15 11 z"
+                      />
+                    </svg>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="copyright">
+            <p>© Copyright 2026 Handsome Photobooth | All Rights Reserved</p>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script src="../assets/js/swiper.js"></script>
+    <script src="../assets/js/script.js"></script>
+    <script src="../assets/js/fslightbox.js"></script>
+    <script src="../assets/js/share.js"></script>
+  </body>
+</html>

--- a/blog/blog_3.html
+++ b/blog/blog_3.html
@@ -1,211 +1,442 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6RDG7BCNMX"></script>
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-6RDG7BCNMX"
+    ></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
-
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
-
-        gtag('config', 'G-6RDG7BCNMX');
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-6RDG7BCNMX");
     </script>
-    <meta name="robots" content="index, follow">
-    <link rel="canonical" href="https://handsomephotobooth.com/blog/blog_3.html">
-    <title>Bay Area Wedding Photo Booth Cost Guide | Handsome Photobooth</title>
-    <meta name="description"
-        content="See Bay Area wedding photo booth pricing, what is usually included, and which venue, timing, print, and add-on choices affect the final rental cost.">
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="keywords"
-        content="photo booth rental bay area,">
-    <link rel="icon" type="image/x-icon" href="../assets/images/favicon.png">
-    <meta property="og:url" content="https://handsomephotobooth.com/blog/blog_3.html">
-    <meta property="og:type" content="article">
-    <meta property="og:site_name" content="Handsome Photobooth">
-    <meta property="og:title" content="Bay Area Wedding Photo Booth Cost Guide">
-    <meta property="og:description"
-        content="See Bay Area wedding photo booth pricing, what is usually included, and which venue, timing, print, and add-on choices affect the final rental cost.">
-    <meta property="og:image" content="https://handsomephotobooth.com/assets/images/photobooth.jpg">
-    <meta property="og:image:type" content="image/jpg">
-    <link rel="stylesheet" href="../assets/css/reset.css">
-    <link rel="stylesheet" href="../assets/css/style_blog.css">
-    <link rel="stylesheet" href="../assets/css/swiper.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+
+    <meta name="robots" content="index, follow" />
+    <link
+      rel="canonical"
+      href="https://handsomephotobooth.com/blog/blog_3.html"
+    />
+    <title>
+      Bay Area Wedding Photo Booth Cost Guide | Handsome Photobooth
+    </title>
+    <meta
+      name="description"
+      content="How much does a wedding photo booth rental cost in the San Francisco Bay Area? See standard prices, hidden fees, and cost-saving tips."
+    />
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="keywords"
+      content="wedding photo booth cost, photo booth rental price, photo booth rental bay area, affordable wedding photo booth, DSLR photo booth cost, photo booth hidden fees"
+    />
+    <link rel="icon" type="image/x-icon" href="../assets/images/favicon.png" />
+
+    <!-- Open Graph / Social Media Preview -->
+    <meta property="og:url" content="https://handsomephotobooth.com/blog/blog_3.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="Handsome Photobooth" />
+    <meta
+      property="og:title"
+      content="Bay Area Wedding Photo Booth Cost Guide"
+    />
+    <meta
+      property="og:description"
+      content="Typical pricing, hidden fees, and expert money-saving tips for renting a wedding photo booth in the San Francisco Bay Area."
+    />
+    <meta
+      property="og:image"
+      content="https://handsomephotobooth.com/assets/images/photobooth.jpg"
+    />
+    <meta property="og:image:type" content="image/jpeg" />
+
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="../assets/css/reset.css" />
+    <link rel="stylesheet" href="../assets/css/style_blog.css" />
+    <link rel="stylesheet" href="../assets/css/swiper.css" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <!-- JSON-LD Structured Schema -->
     <script type="application/ld+json">
-        {
-            "@context": "https://schema.org",
-            "@type": "BlogPosting",
-            "headline": "Bay Area Wedding Photo Booth Cost Guide",
-            "description": "See Bay Area wedding photo booth pricing, what is usually included, and which venue, timing, print, and add-on choices affect the final rental cost.",
-            "image": "https://handsomephotobooth.com/assets/images/photobooth.jpg",
-            "datePublished": "2023-10-01",
-            "dateModified": "2023-10-01",
-            "author": {
-                "@type": "Person",
-                "name": "Leo Yeung"
-            },
-            "publisher": {
-                "@type": "Organization",
-                "name": "Handsome Photobooth",
-                "logo": {
-                    "@type": "ImageObject",
-                    "url": "https://handsomephotobooth.com/assets/images/logo.png"
-                }
-            },
-            "mainEntityOfPage": {
-                "@type": "WebPage",
-                "@id": "https://handsomephotobooth.com/blog/blog_3.html"
-            },
-            "articleSection": "Pricing Guide",
-            "inLanguage": "en-US"
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Bay Area Wedding Photo Booth Cost Guide",
+        "description": "How much does it cost to rent a wedding photo booth in the San Francisco Bay Area? Explore average pricing tiers, hidden logistical fees, and money-saving hacks.",
+        "image": "https://handsomephotobooth.com/assets/images/photobooth.jpg",
+        "datePublished": "2023-10-01",
+        "dateModified": "2026-05-21",
+        "author": {
+          "@type": "Person",
+          "name": "Leo Yeung",
+          "jobTitle": "Lead Photographer & Owner",
+          "sameAs": [
+            "https://www.linkedin.com/in/leokyeung/"
+          ]
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Handsome Photobooth",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://handsomephotobooth.com/assets/images/logo.png"
+          }
+        },
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "https://handsomephotobooth.com/blog/blog_3.html"
+        },
+        "articleSection": "Pricing Guide",
+        "inLanguage": "en-US"
+      }
     </script>
-</head>
+  </head>
 
-<body class="article-page">
+  <body class="article-page">
     <div id="fb-root"></div>
     <div id="fb-customer-chat" class="fb-customerchat"></div>
     <script>
-        var chatbox = document.getElementById("fb-customer-chat");
-        chatbox.setAttribute("page_id", "102230392638740");
-        chatbox.setAttribute("attribution", "biz_inbox");
+      var chatbox = document.getElementById("fb-customer-chat");
+      chatbox.setAttribute("page_id", "102230392638740");
+      chatbox.setAttribute("attribution", "biz_inbox");
     </script>
     <script>
-        window.fbAsyncInit = function () {
-            FB.init({
-                xfbml: true,
-                version: "v15.0",
-            });
-        };
+      window.fbAsyncInit = function () {
+        FB.init({
+          xfbml: true,
+          version: "v15.0",
+        });
+      };
 
-        (function (d, s, id) {
-            var js,
-                fjs = d.getElementsByTagName(s)[0];
-            if (d.getElementById(id)) return;
-            js = d.createElement(s);
-            js.id = id;
-            js.src =
-                "https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js";
-            fjs.parentNode.insertBefore(js, fjs);
-        })(document, "script", "facebook-jssdk");
+      (function (d, s, id) {
+        var js,
+          fjs = d.getElementsByTagName(s)[0];
+        if (d.getElementById(id)) return;
+        js = d.createElement(s);
+        js.id = id;
+        js.src = "https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js";
+        fjs.parentNode.insertBefore(js, fjs);
+      })(document, "script", "facebook-jssdk");
     </script>
-    <header>
-        <div class="nav-container">
-            <div class="container">
-                <nav> <a href="https://handsomephotobooth.com/" class="logo"> <img src="../assets/images/logo.png"
-                            alt="Handsome Photobooth"> </a> <a href="https://handsomephotobooth.com/#contact"
-                        class="btn_top">Contact Us</a>
-                    <ul class="nav-list">
-                        <li> <a href="https://handsomephotobooth.com/#about" class="nav-link">About Us</a> </li>
-                        <li> <a href="https://handsomephotobooth.com/#pricing" class="nav-link">Package & Equipment</a>
-                        </li>
-                        <li> <a href="https://handsomephotobooth.com/#contact" class="nav-link">Contact Us</a> </li>
-                        <li> <a href="https://handsomephotobooth.com/blog/blog.html" class="nav-link">Blog</a> </li>
-                    </ul>
-                    <div class="hamburger"> <span></span> <span></span> <span></span> <span></span> </div>
-                </nav>
-            </div>
-        </div>
-    </header>
-    <main>
-        <section class="hero-section" id="home">
-            <div class="container">
-                <div class="hero-content"> <a href="https://handsomephotobooth.com/blog/blog.html">Back To Home</a>
-                    <h1>How Much Does a Wedding Photo Booth Cost in the Bay Area?</h1>
-                </div>
-            </div>
-        </section>
-        <section class="article-section">
-            <div class="container">
-                <div class="article-content">
-                    <div class="article-img"> <img src="../assets/images/photobooth.jpg"
-                            style="width:70%; margin-left: auto; margin-right: auto"
-                            alt="Wedding photo booth setup used for a Bay Area pricing guide"> </div>
-                    <article>
-                        <p>When planning a wedding in the picturesque Bay Area, adding a photo booth to your celebration can be a delightful and memorable touch. Photo booths offer an entertaining experience for guests while capturing candid moments. If you're wondering about the cost of renting a photo booth in the Bay Area, you've come to the right place.</p>
 
-                        <h2>What Is Usually Included in a Bay Area Photo Booth Package?</h2>
-                        <p>Photo booth rentals in the Bay Area typically include a range of services that contribute to the total cost. A standard package often encompasses:</p>
-                        <ul>
-                          <li>&emsp;&emsp;Rental Duration: Most providers offer packages based on hours of service. For a wedding, a popular choice is a three-hour rental, which provides ample time for guests to enjoy the booth without it dominating the entire event.</li>
-                          <br/>
-                          <li>&emsp;&emsp;Unlimited Prints: Many packages include unlimited photo prints during the rental period. This means guests can take home as many photo strips as they like, creating lasting mementos.</li>
-                          <br/>
-                          <li>&emsp;&emsp;Customization: To make your wedding photo booth unique, customization options are available. You can select personalized templates and overlays to match your wedding theme and style.</li>
-                          <br/>
-                          <li>&emsp;&emsp;Props and Backdrops: Most photo booth rentals include a variety of props and backdrops to add an element of fun and creativity to the photos.</li>
-                          <br/>
-                          <li>&emsp;&emsp;Digital Copies: Many providers offer digital copies of all photos taken during the event. This is a fantastic way to access and share the memories online instantly.</li>
-                        </ul>
-                      <br/>
-                        <h2>What Changes the Final Wedding Photo Booth Cost?</h2>
-                        <p>The cost of a photo booth for a wedding in the Bay Area typically ranges from $600 to $1000 for a three-hour service. However, it's essential to note that several factors can influence the final price:</p>
-                        <ul>
-                          <li>&emsp;&emsp;Location: The specific location within the Bay Area can impact the cost. Downtown San Francisco venues, for instance, may have different pricing compared to those in the surrounding suburbs.</li>
-                          <br/>
-                          <li>&emsp;&emsp;Additional Hours: If you require the photo booth for longer than the standard three hours, there may be an extra charge for each additional hour.</li>
-                          <br/>
-                          <li>&emsp;&emsp;Weekend vs. Weekday: Weekend rentals are often in higher demand and may come with a slightly higher price tag compared to weekday rentals.</li>
-                          <br/>
-                          <li>&emsp;&emsp;Package Inclusions: Some providers offer additional services, such as premium props, custom scrapbooks, or social media sharing stations. These can add to the overall cost.</li>
-                          <br/>
-                          <li>&emsp;&emsp;Travel Fees: Depending on the location of your wedding venue, there may be travel fees associated with bringing the photo booth to your event.</li>
-                        </ul>
-                        <br/>
-                        <h2>Choosing the Right Photo Booth Provider</h2>
-                        <p>When selecting a photo booth rental for your Bay Area wedding, consider your budget and the services that matter most to you. It's advisable to request quotes from multiple providers, inquire about package details, and read reviews to ensure you choose a reputable and reliable company.</p>
-                        <p><em>Remember to plan ahead and book your photo booth in advance to secure your desired date and package. Your guests will undoubtedly appreciate the entertainment, and you'll cherish the photo booth memories for years to come.</em></p>
-                        <p><strong>In conclusion</strong>, the cost of a photo booth for your Bay Area wedding can vary, but a standard three-hour rental typically falls within the range of $600 to $1000. To find the best fit for your wedding, explore options, customize your experience, and make your celebration unforgettable with the addition of a photo booth.</p>
-                        <p>Ready to lock in your date? See our dedicated <a class="blog-link" href="https://handsomephotobooth.com/bay-area-wedding-photo-booth.html">Bay Area wedding photo booth rental</a> page for the full Glam Package and reviews from real couples.</p>
-                        <p>Explore our blog at <a class="blog-link" href="https://handsomephotobooth.com/blog/blog_2.html">How to Choose a Bay Area Photo Booth Vendor</a> for additional insights and valuable tips. Our blog covers a wide range of topics related to photo booths and event planning. Visit our <a class="blog-link" href="https://handsomephotobooth.com/blog/blog.html">blog</a> for expert advice to enhance your upcoming celebration.</p>
-                    </article>
-                </div>
-            </div>
-        </section>
-    </main>
-    <footer>
+    <header>
+      <div class="nav-container">
         <div class="container">
-            <div class="footer-content">
-                <div class="footer-nav">
-                    <div>
-                        <h5 class="gradient">Follow Us!</h5>
-                        <ul class="social-list">
-                            <li>
-                                <a href="https://www.instagram.com/handsomephotobooth/" target="_blank" rel="noopener noreferrer" aria-label="Follow Handsome Photobooth on Instagram">
-                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
-                                        <defs>
-                                            <linearGradient id="instagram-gradient" x1="0%" y1="100%" x2="100%" y2="0%">
-                                                <stop offset="0%" style="stop-color:#feda75;stop-opacity:1" />
-                                                <stop offset="25%" style="stop-color:#fa7e1e;stop-opacity:1" />
-                                                <stop offset="50%" style="stop-color:#d62976;stop-opacity:1" />
-                                                <stop offset="75%" style="stop-color:#962fbf;stop-opacity:1" />
-                                                <stop offset="100%" style="stop-color:#4f5bd5;stop-opacity:1" />
-                                            </linearGradient>
-                                        </defs>
-                                        <path fill="url(#instagram-gradient)" d="M9.9980469 3C6.1390469 3 3 6.1419531 3 10.001953L3 20.001953C3 23.860953 6.1419531 27 10.001953 27L20.001953 27C23.860953 27 27 23.858047 27 19.998047L27 9.9980469C27 6.1390469 23.858047 3 19.998047 3L9.9980469 3 z M 22 7C22.552 7 23 7.448 23 8C23 8.552 22.552 9 22 9C21.448 9 21 8.552 21 8C21 7.448 21.448 7 22 7 z M 15 9C18.309 9 21 11.691 21 15C21 18.309 18.309 21 15 21C11.691 21 9 18.309 9 15C9 11.691 11.691 9 15 9 z M 15 11 A 4 4 0 0 0 11 15 A 4 4 0 0 0 15 19 A 4 4 0 0 0 19 15 A 4 4 0 0 0 15 11 z" />
-                                    </svg>
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="copyright">
-                    <p> © Copyright 2026 Handsome Photobooth | All Rights Reserved </p>
-                </div>
+          <nav>
+            <a href="https://handsomephotobooth.com/" class="logo">
+              <img
+                src="../assets/images/logo.png"
+                alt="Handsome Photobooth Logo"
+              />
+            </a>
+            <a href="https://handsomephotobooth.com/#contact" class="btn_top"
+              >Contact Us</a
+            >
+            <ul class="nav-list">
+              <li>
+                <a href="https://handsomephotobooth.com/#about" class="nav-link"
+                  >About Us</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/#pricing"
+                  class="nav-link"
+                  >Package & Equipment</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/#contact"
+                  class="nav-link"
+                  >Contact Us</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/blog/blog.html"
+                  class="nav-link"
+                  >Blog</a
+                >
+              </li>
+            </ul>
+            <div class="hamburger">
+              <span></span>
+              <span></span>
+              <span></span>
+              <span></span>
             </div>
+          </nav>
         </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero-section" id="home">
+        <div class="container">
+          <div class="hero-content">
+            <a href="https://handsomephotobooth.com/blog/blog.html"
+              >Back To Blog</a
+            >
+            <h1>How Much Does a Wedding Photo Booth Cost in the Bay Area?</h1>
+          </div>
+        </div>
+      </section>
+
+      <section class="article-section">
+        <div class="container">
+          <div class="article-content">
+            <div class="article-img">
+              <img
+                src="../assets/images/photobooth.jpg"
+                style="width: 70%; margin-left: auto; margin-right: auto"
+                alt="Wedding photo booth setup for high-quality event photography"
+              />
+            </div>
+            <article>
+              <p>
+                When planning a wedding in the beautiful San Francisco Bay Area, 
+                establishing your budget is one of the first and most important steps. 
+                Whether your venue is a rustic vineyard in Napa, an elegant estate in 
+                Silicon Valley, or a chic industrial loft in downtown San Francisco, 
+                adding a photo booth is one of the most popular ways to keep guests 
+                entertained and provide memorable favors.
+              </p>
+              <p>
+                But how much does a wedding photo booth rental actually cost in the 
+                Bay Area? On average, couples spend between <strong>$600 and $1,200</strong> 
+                for a standard three-to-four-hour package. 
+              </p>
+              <p>
+                In this complete cost guide, we'll break down the average pricing tiers, 
+                explain exactly what is included in standard packages, highlight hidden 
+                logistical fees to watch out for, and share expert tips on how to maximize 
+                your value.
+              </p>
+
+              <h2>1. Bay Area Photo Booth Pricing Tiers</h2>
+              <p>
+                Not all photo booths are built equal, and the technology used dictates 
+                the price. Here are the primary tiers of photo booths available in the 
+                Bay Area marketplace:
+              </p>
+              <ul>
+                <li>
+                  <strong>Budget / Digital-Only iPad Booths ($300 – $500):</strong> 
+                  These are typically self-service or basic setups that utilize an iPad. 
+                  They rarely offer physical printing and are digital-only (GIFs and 
+                  texts). Lighting is usually just a basic LED ring light, and there is 
+                  rarely an attendant on-site.
+                </li>
+                <br />
+                <li>
+                  <strong>Standard Open-Air DSLR Booths ($650 – $950):</strong> 
+                  The sweet spot for weddings. These professional systems feature a 
+                  high-quality DSLR camera, a studio umbrella flash, a premium fabric backdrop, 
+                  unlimited high-speed physical prints, and an on-site attendant.
+                </li>
+                <br />
+                <li>
+                  <strong>Glitter / "Black & White" Glam Booths ($800 – $1,200):</strong> 
+                  Inspired by celebrity events, these booths use specialized studio lenses and 
+                  custom smoothing filters to produce flawless black-and-white or high-contrast 
+                  color portraits. They often feature minimalist white backdrops and 4x6 print formats.
+                </li>
+                <br />
+                <li>
+                  <strong>Specialty / 360 Video & Roaming Booths ($1,200 – $2,000+):</strong> 
+                  Interactive experiences where guests stand on an elevated platform while a camera 
+                  spins 360 degrees around them, producing high-definition slow-motion videos 
+                  with music overlays.
+                </li>
+              </ul>
+
+              <h2>2. What Is Typically Included in a Standard Package?</h2>
+              <p>
+                When comparing quotes from reputable Bay Area suppliers, a standard, 
+                all-inclusive wedding photo booth package should include:
+              </p>
+              <ul>
+                <li>
+                  <strong>Rental Duration:</strong> Usually 3 operating hours, which is 
+                  the perfect amount of time to capture all your guests without paying for 
+                  "dead time" during formal sit-down dinners.
+                </li>
+                <li>
+                  <strong>Unlimited Instant Prints:</strong> High-speed commercial printers 
+                  that print lab-quality photo strips in under 15 seconds.
+                </li>
+                <li>
+                  <strong>Custom Template Design:</strong> A personalized print overlay matching your 
+                  exact wedding theme, typography, and colors.
+                </li>
+                <li>
+                  <strong>Attendant on Duty:</strong> A friendly, professional host to keep the 
+                  props organized, guide guests on poses, and manage lines.
+                </li>
+                <li>
+                  <strong>Full Digital Gallery:</strong> Access to download all individual photos and 
+                  full print templates via a digital album (like Google Photos) after the event.
+                </li>
+              </ul>
+
+              <h2>3. Hidden Fees & Logistical Costs to Watch Out For</h2>
+              <p>
+                To avoid unexpected expenses, always check your contract for these common 
+                Bay Area logistical fees:
+              </p>
+              <ul>
+                <li>
+                  <strong>Bridge Tolls & Travel Fees:</strong> Many vendors charge extra travel 
+                  fees if your venue is outside of their immediate radius (for example, traveling from 
+                  the East Bay to Napa, Sonoma, or Carmel).
+                </li>
+                <li>
+                  <strong>Downtown Parking:</strong> If your venue is in downtown San Francisco, 
+                  Oakland, or San Jose, parking for a large van with loading gear can be expensive. 
+                  Verify if the vendor includes parking in their fee or bills it back to you.
+                </li>
+                <li>
+                  <strong>Idle Hours:</strong> If you need the booth set up at 4:00 PM for cocktail hour, 
+                  but want to pause it during dinner and speeches from 6:00 to 7:30 PM, vendors charge 
+                  an "idle hour" rate (usually $50–$75/hr) because their attendant is still on-site.
+                </li>
+                <li>
+                  <strong>Early Setup Fees:</strong> If your venue coordinator requires all vendors to be 
+                  fully set up hours before the event starts, you may face early load-in charges.
+                </li>
+              </ul>
+
+              <h2>4. Expert Money-Saving Tips for Your Rental</h2>
+              <p>
+                If you are looking to fit a high-end DSLR photo booth into your budget, here are a 
+                few industry tips to keep costs down:
+              </p>
+              <ul>
+                <li>
+                  <strong>Schedule "Idle Time" Wisely:</strong> Instead of keeping the booth active 
+                  for 5 hours straight, book a 3-hour active package. Have it open for cocktail hour (1 hour), 
+                  close it during dinner, and reopen it for dancing (2 hours). This avoids paying for 
+                  operating hours when no one is using the booth.
+                </li>
+                <li>
+                  <strong>Avoid Holiday/Peak-Season Add-ons:</strong> Peak wedding season in the Bay Area 
+                  runs from May through October. Booking on a Friday or Sunday, or during the off-season winter 
+                  months, can sometimes unlock promotional discounts.
+                </li>
+                <li>
+                  <strong>Check your placement:</strong> Make sure the booth is highly visible. If you place 
+                  it in a separate room, you are wasting your rental hours because fewer guests will find it. 
+                  Learn more in our <a href="./wedding-photo-booth-timeline.html" style="color: #ff6b6b; font-weight: 600; text-decoration: underline;">Wedding Photo Booth Timeline & Placement Guide</a>.
+                </li>
+              </ul>
+
+              <h2>Making the Right Choice</h2>
+              <p>
+                While budget is important, don't sacrifice technical quality. A cheap iPad booth might save 
+                you $200, but you risk grainy photos, long lines, and prints that smudge. 
+              </p>
+              <p>
+                To ensure your wedding photos look absolutely stunning, always choose a vendor with a strong 
+                track record. Read our comprehensive checklist on 
+                <a href="./blog_2.html" style="color: #ff6b6b; font-weight: 600; text-decoration: underline;">How to Choose a Bay Area Photo Booth Vendor</a> 
+                before signing any contract.
+              </p>
+
+              <p style="text-align: center; margin-top: 40px; font-style: italic;">
+                At Handsome Photobooth, we believe in transparent, all-inclusive local pricing. 
+                Our 3-hour Glam Package includes high-end DSLR cameras, professional studio flash 
+                umbrellas, and unlimited high-speed prints with no hidden setup or travel fees in our standard area.
+              </p>
+
+              <p style="text-align: center; margin-top: 20px;">
+                Explore our full 
+                <a class="blog-link" href="https://handsomephotobooth.com/bay-area-wedding-photo-booth.html" style="font-weight: 700; color: #ff6b6b;">Bay Area Wedding Photo Booth Rental</a> 
+                package, and 
+                <a class="blog-link" href="https://handsomephotobooth.com/#contact" style="font-weight: 700; color: #ff6b6b;">contact us today</a> to lock in your date!
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container">
+        <div class="footer-content">
+          <div class="footer-nav">
+            <div>
+              <h5 class="gradient">Follow Us!</h5>
+              <ul class="social-list">
+                <li>
+                  <a
+                    href="https://www.instagram.com/handsomephotobooth/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Follow Handsome Photobooth on Instagram"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+                      <defs>
+                        <linearGradient
+                          id="instagram-gradient"
+                          x1="0%"
+                          y1="100%"
+                          x2="100%"
+                          y2="0%"
+                        >
+                          <stop
+                            offset="0%"
+                            style="stop-color: #feda75; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="25%"
+                            style="stop-color: #fa7e1e; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="50%"
+                            style="stop-color: #d62976; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="75%"
+                            style="stop-color: #962fbf; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="100%"
+                            style="stop-color: #4f5bd5; stop-opacity: 1"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <path
+                        fill="url(#instagram-gradient)"
+                        d="M9.9980469 3C6.1390469 3 3 6.1419531 3 10.001953L3 20.001953C3 23.860953 6.1419531 27 10.001953 27L20.001953 27C23.860953 27 27 23.858047 27 19.998047L27 9.9980469C27 6.1390469 23.858047 3 19.998047 3L9.9980469 3 z M 22 7C22.552 7 23 7.448 23 8C23 8.552 22.552 9 22 9C21.448 9 21 8.552 21 8C21 7.448 21.448 7 22 7 z M 15 9C18.309 9 21 11.691 21 15C21 18.309 18.309 21 15 21C11.691 21 9 18.309 9 15C9 11.691 11.691 9 15 9 z M 15 11 A 4 4 0 0 0 11 15 A 4 4 0 0 0 15 19 A 4 4 0 0 0 19 15 A 4 4 0 0 0 15 11 z"
+                      />
+                    </svg>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="copyright">
+            <p>© Copyright 2026 Handsome Photobooth | All Rights Reserved</p>
+          </div>
+        </div>
+      </div>
     </footer>
+
     <script src="../assets/js/swiper.js"></script>
     <script src="../assets/js/script.js"></script>
     <script src="../assets/js/fslightbox.js"></script>
     <script src="../assets/js/share.js"></script>
-</body>
-
+  </body>
 </html>

--- a/blog/wedding-photo-booth-timeline.html
+++ b/blog/wedding-photo-booth-timeline.html
@@ -1,209 +1,461 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6RDG7BCNMX"></script>
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-6RDG7BCNMX"
+    ></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
-
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
-
-        gtag('config', 'G-6RDG7BCNMX');
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-6RDG7BCNMX");
     </script>
-    <meta name="robots" content="index, follow">
-    <link rel="canonical" href="https://handsomephotobooth.com/blog/wedding-photo-booth-timeline.html">
+
+    <meta name="robots" content="index, follow" />
+    <link
+      rel="canonical"
+      href="https://handsomephotobooth.com/blog/wedding-photo-booth-timeline.html"
+    />
     <title>When Should You Open the Photo Booth at Your Wedding?</title>
-    <meta name="description"
-        content="Not sure when to run your wedding photo booth? Compare cocktail hour, dinner, and reception timing so guests actually use it without interrupting the flow.">
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="keywords"
-        content="wedding photo booth timeline, when to have photo booth at wedding, photo booth during cocktail hour, photo booth during reception, Bay Area wedding photo booth">
-    <link rel="icon" type="image/x-icon" href="../assets/images/favicon.png">
-    <meta property="og:url" content="https://handsomephotobooth.com/blog/wedding-photo-booth-timeline.html">
-    <meta property="og:type" content="article">
-    <meta property="og:site_name" content="Handsome Photobooth">
-    <meta property="og:title" content="When Should You Open the Photo Booth at Your Wedding?">
-    <meta property="og:description"
-        content="Compare cocktail hour, dinner, and reception timing so your wedding photo booth fits naturally into the night.">
-    <meta property="og:image" content="https://handsomephotobooth.com/assets/images/wedding-photo-booth-timeline.jpg">
-    <meta property="og:image:type" content="image/jpeg">
-    <link rel="stylesheet" href="../assets/css/reset.css">
-    <link rel="stylesheet" href="../assets/css/style_blog.css">
-    <link rel="stylesheet" href="../assets/css/swiper.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
-    <script type="application/ld+json">
-        {
-            "@context": "https://schema.org",
-            "@type": "BlogPosting",
-            "headline": "When Should You Open the Photo Booth at Your Wedding?",
-            "description": "Not sure when to run your wedding photo booth? Compare cocktail hour, dinner, and reception timing so guests actually use it without interrupting the flow.",
-            "image": "https://handsomephotobooth.com/assets/images/wedding-photo-booth-timeline.jpg",
-            "datePublished": "2026-05-17",
-            "dateModified": "2026-05-17",
-            "author": {
-                "@type": "Person",
-                "name": "Leo Yeung"
-            },
-            "publisher": {
-                "@type": "Organization",
-                "name": "Handsome Photobooth",
-                "logo": {
-                    "@type": "ImageObject",
-                    "url": "https://handsomephotobooth.com/assets/images/logo.png"
-                }
-            },
-            "mainEntityOfPage": {
-                "@type": "WebPage",
-                "@id": "https://handsomephotobooth.com/blog/wedding-photo-booth-timeline.html"
-            },
-            "articleSection": "Wedding Planning",
-            "inLanguage": "en-US"
-        }
-    </script>
-</head>
+    <meta
+      name="description"
+      content="Not sure when to run your wedding photo booth? Compare cocktail hour, dinner, and reception timing so guests actually use it without interrupting the flow."
+    />
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="keywords"
+      content="wedding photo booth timeline, when to have photo booth at wedding, photo booth during cocktail hour, photo booth during reception, Bay Area wedding photo booth"
+    />
+    <link rel="icon" type="image/x-icon" href="../assets/images/favicon.png" />
 
-<body class="article-page">
+    <!-- Open Graph / Social Media Preview -->
+    <meta property="og:url" content="https://handsomephotobooth.com/blog/wedding-photo-booth-timeline.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="Handsome Photobooth" />
+    <meta
+      property="og:title"
+      content="When Should You Open the Photo Booth at Your Wedding?"
+    />
+    <meta
+      property="og:description"
+      content="Compare cocktail hour, dinner, and reception timing so your wedding photo booth fits naturally into the night."
+    />
+    <meta
+      property="og:image"
+      content="https://handsomephotobooth.com/assets/images/wedding-photo-booth-timeline.jpg"
+    />
+    <meta property="og:image:type" content="image/jpeg" />
+
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="../assets/css/reset.css" />
+    <link rel="stylesheet" href="../assets/css/style_blog.css" />
+    <link rel="stylesheet" href="../assets/css/swiper.css" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <!-- JSON-LD Structured Schema -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "When Should You Open the Photo Booth at Your Wedding?",
+        "description": "Not sure when to run your wedding photo booth? Compare cocktail hour, dinner, and reception timing so guests actually use it without interrupting the flow.",
+        "image": "https://handsomephotobooth.com/assets/images/wedding-photo-booth-timeline.jpg",
+        "datePublished": "2026-05-17",
+        "dateModified": "2026-05-21",
+        "author": {
+          "@type": "Person",
+          "name": "Leo Yeung",
+          "jobTitle": "Lead Photographer & Owner",
+          "sameAs": [
+            "https://www.linkedin.com/in/leokyeung/"
+          ]
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Handsome Photobooth",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://handsomephotobooth.com/assets/images/logo.png"
+          }
+        },
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "https://handsomephotobooth.com/blog/wedding-photo-booth-timeline.html"
+        },
+        "articleSection": "Wedding Planning",
+        "inLanguage": "en-US"
+      }
+    </script>
+  </head>
+
+  <body class="article-page">
     <div id="fb-root"></div>
     <div id="fb-customer-chat" class="fb-customerchat"></div>
     <script>
-        var chatbox = document.getElementById("fb-customer-chat");
-        chatbox.setAttribute("page_id", "102230392638740");
-        chatbox.setAttribute("attribution", "biz_inbox");
+      var chatbox = document.getElementById("fb-customer-chat");
+      chatbox.setAttribute("page_id", "102230392638740");
+      chatbox.setAttribute("attribution", "biz_inbox");
     </script>
     <script>
-        window.fbAsyncInit = function () {
-            FB.init({
-                xfbml: true,
-                version: "v15.0",
-            });
-        };
+      window.fbAsyncInit = function () {
+        FB.init({
+          xfbml: true,
+          version: "v15.0",
+        });
+      };
 
-        (function (d, s, id) {
-            var js,
-                fjs = d.getElementsByTagName(s)[0];
-            if (d.getElementById(id)) return;
-            js = d.createElement(s);
-            js.id = id;
-            js.src =
-                "https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js";
-            fjs.parentNode.insertBefore(js, fjs);
-        })(document, "script", "facebook-jssdk");
+      (function (d, s, id) {
+        var js,
+          fjs = d.getElementsByTagName(s)[0];
+        if (d.getElementById(id)) return;
+        js = d.createElement(s);
+        js.id = id;
+        js.src = "https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js";
+        fjs.parentNode.insertBefore(js, fjs);
+      })(document, "script", "facebook-jssdk");
     </script>
+
     <header>
-        <div class="nav-container">
-            <div class="container">
-                <nav> <a href="https://handsomephotobooth.com/" class="logo"> <img src="../assets/images/logo.png"
-                            alt="Handsome Photobooth"> </a> <a href="https://handsomephotobooth.com/#contact"
-                        class="btn_top">Contact Us</a>
-                    <ul class="nav-list">
-                        <li> <a href="https://handsomephotobooth.com/#about" class="nav-link">About Us</a> </li>
-                        <li> <a href="https://handsomephotobooth.com/#pricing" class="nav-link">Package & Equipment</a> </li>
-                        <li> <a href="https://handsomephotobooth.com/#contact" class="nav-link">Contact Us</a> </li>
-                        <li> <a href="https://handsomephotobooth.com/blog/blog.html" class="nav-link">Blog</a> </li>
-                    </ul>
-                    <div class="hamburger"> <span></span> <span></span> <span></span> <span></span> </div>
-                </nav>
-            </div>
-        </div>
-    </header>
-    <main>
-        <section class="hero-section" id="home">
-            <div class="container">
-                <div class="hero-content"> <a href="https://handsomephotobooth.com/blog/blog.html">Back To Home</a>
-                    <h1>When Should You Open the Photo Booth at Your Wedding?</h1>
-                </div>
-            </div>
-        </section>
-        <section class="article-section">
-            <div class="container">
-                <div class="article-content">
-                    <div class="article-img"> <img src="../assets/images/wedding-photo-booth-timeline.jpg"
-                            style="width:70%; margin-left: auto; margin-right: auto"
-                            alt="Open-air wedding photo booth set up near cocktail hour at an evening reception"> </div>
-                    <article>
-                        <p>A photo booth works best when guests naturally have a little free time. The goal is not just to have the booth available. The goal is to open it when people are relaxed, nearby, and ready to jump in without feeling like they are missing dinner, speeches, or the dance floor.</p>
-                        <p>For most weddings, the best photo booth timing is either cocktail hour through early reception or after dinner through dancing. The right choice depends on your venue layout, guest count, and how packed your timeline is.</p>
-
-                        <h2>Option 1: Open During Cocktail Hour</h2>
-                        <p>Cocktail hour is one of the easiest times to start the photo booth. Guests have arrived, they are dressed up, and they are usually looking for something to do while the couple takes portraits or the reception space gets finalized.</p>
-                        <p>This works especially well if the booth is near the bar, lounge area, or reception entrance. Guests can grab a drink, take photos, and start the evening with something fun before formal events begin.</p>
-                        <p>The only downside is that cocktail hour can go fast. If your venue is moving guests between spaces, or if the booth is tucked away from the main flow, some people may miss it.</p>
-
-                        <h2>Option 2: Open After Dinner</h2>
-                        <p>Opening after dinner can work really well because guests are settled, speeches are usually done, and people are starting to move around. This is often when the booth line gets busiest.</p>
-                        <p>If you want the booth to feel like part of the party, this is a strong option. Guests have more time, groups are easier to gather, and the photos often get funnier as the night goes on.</p>
-                        <p>The main thing to watch is timing. If the booth opens too late, older guests or families with kids may leave before using it. If you have a lot of guests who may head out early, consider opening before dinner ends or right after the first dances.</p>
-
-                        <h2>Option 3: Keep It Open Through Dancing</h2>
-                        <p>A photo booth near the dance floor can add a lot of energy. Guests take a few photos, dance, come back with a different group, and take more. This is when unlimited prints and QR downloads really matter because people tend to use the booth more than once.</p>
-                        <p>This timing works best when your booth is easy to see and not hidden in a hallway. If guests have to leave the party completely to find it, usage usually drops.</p>
-
-                        <h2>A Strong Three-Hour Booth Timeline</h2>
-                        <p>For a typical Bay Area wedding, a good three-hour booth window is cocktail hour through early dancing, or dinner ending through the dance floor.</p>
-                        <p>If your package is three hours, I usually would not spend the whole booth time during dinner. Guests are seated, food is being served, and people are less likely to leave the table unless there is a natural break.</p>
-                        <p>A strong setup might look like this:</p>
-                        <ul>
-                            <li>&emsp;&emsp;Open the booth near the end of cocktail hour.</li>
-                            <li>&emsp;&emsp;Let guests use it before dinner or during the room transition.</li>
-                            <li>&emsp;&emsp;Let speeches and formal moments happen without forcing booth traffic.</li>
-                            <li>&emsp;&emsp;Expect the booth to get busy again after dinner and first dances.</li>
-                        </ul>
-
-                        <h2>Where Should the Photo Booth Be Placed?</h2>
-                        <p>Timing matters, but placement matters just as much. The booth should be close enough that guests notice it, but not so close that it blocks catering, speeches, or the dance floor.</p>
-                        <p>Good spots include near the bar, near the reception entrance, beside the dance floor, or in a visible lounge or foyer area. Avoid placing it too far outside the main reception space unless there are signs or the venue naturally sends guests that way.</p>
-
-                        <h2>Final Recommendation</h2>
-                        <p>If you are not sure, open the photo booth earlier rather than later. Guests look their freshest near the beginning of the night, families are still around, and the booth can help warm up the reception before dancing starts.</p>
-                        <p>For Bay Area weddings, Handsome Photobooth includes setup, an attendant, unlimited prints, QR downloads, and a custom template, so the booth can fit naturally into your timeline without adding another thing for you to manage. See our <a class="blog-link" href="https://handsomephotobooth.com/bay-area-wedding-photo-booth.html">Bay Area wedding photo booth rental</a> package for details.</p>
-                    </article>
-                </div>
-            </div>
-        </section>
-    </main>
-    <footer>
+      <div class="nav-container">
         <div class="container">
-            <div class="footer-content">
-                <div class="footer-nav">
-                    <div>
-                        <h5 class="gradient">Follow Us!</h5>
-                        <ul class="social-list">
-                            <li>
-                                <a href="https://www.instagram.com/handsomephotobooth/" target="_blank" rel="noopener noreferrer" aria-label="Follow Handsome Photobooth on Instagram">
-                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
-                                        <defs>
-                                            <linearGradient id="instagram-gradient" x1="0%" y1="100%" x2="100%" y2="0%">
-                                                <stop offset="0%" style="stop-color:#feda75;stop-opacity:1" />
-                                                <stop offset="25%" style="stop-color:#fa7e1e;stop-opacity:1" />
-                                                <stop offset="50%" style="stop-color:#d62976;stop-opacity:1" />
-                                                <stop offset="75%" style="stop-color:#962fbf;stop-opacity:1" />
-                                                <stop offset="100%" style="stop-color:#4f5bd5;stop-opacity:1" />
-                                            </linearGradient>
-                                        </defs>
-                                        <path fill="url(#instagram-gradient)" d="M9.9980469 3C6.1390469 3 3 6.1419531 3 10.001953L3 20.001953C3 23.860953 6.1419531 27 10.001953 27L20.001953 27C23.860953 27 27 23.858047 27 19.998047L27 9.9980469C27 6.1390469 23.858047 3 19.998047 3L9.9980469 3 z M 22 7C22.552 7 23 7.448 23 8C23 8.552 22.552 9 22 9C21.448 9 21 8.552 21 8C21 7.448 21.448 7 22 7 z M 15 9C18.309 9 21 11.691 21 15C21 18.309 18.309 21 15 21C11.691 21 9 18.309 9 15C9 11.691 11.691 9 15 9 z M 15 11 A 4 4 0 0 0 11 15 A 4 4 0 0 0 15 19 A 4 4 0 0 0 19 15 A 4 4 0 0 0 15 11 z" />
-                                    </svg>
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="copyright">
-                    <p> © Copyright 2026 Handsome Photobooth | All Rights Reserved </p>
-                </div>
+          <nav>
+            <a href="https://handsomephotobooth.com/" class="logo">
+              <img
+                src="../assets/images/logo.png"
+                alt="Handsome Photobooth Logo"
+              />
+            </a>
+            <a href="https://handsomephotobooth.com/#contact" class="btn_top"
+              >Contact Us</a
+            >
+            <ul class="nav-list">
+              <li>
+                <a href="https://handsomephotobooth.com/#about" class="nav-link"
+                  >About Us</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/#pricing"
+                  class="nav-link"
+                  >Package & Equipment</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/#contact"
+                  class="nav-link"
+                  >Contact Us</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://handsomephotobooth.com/blog/blog.html"
+                  class="nav-link"
+                  >Blog</a
+                >
+              </li>
+            </ul>
+            <div class="hamburger">
+              <span></span>
+              <span></span>
+              <span></span>
+              <span></span>
             </div>
+          </nav>
         </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero-section" id="home">
+        <div class="container">
+          <div class="hero-content">
+            <a href="https://handsomephotobooth.com/blog/blog.html"
+              >Back To Blog</a
+            >
+            <h1>When Should You Open the Photo Booth at Your Wedding?</h1>
+          </div>
+        </div>
+      </section>
+
+      <section class="article-section">
+        <div class="container">
+          <div class="article-content">
+            <div class="article-img">
+              <img
+                src="../assets/images/wedding-photo-booth-timeline.jpg"
+                style="width: 70%; margin-left: auto; margin-right: auto"
+                alt="Open-air wedding photo booth set up near cocktail hour at an evening reception"
+              />
+            </div>
+            <article>
+              <p>
+                A photo booth works best when guests naturally have a little free
+                time. The goal is not just to have the booth available. The goal
+                is to open it when people are relaxed, nearby, and ready to jump
+                in without feeling like they are missing dinner, speeches, or the
+                dance floor.
+              </p>
+              <p>
+                For most weddings, the best photo booth timing is either cocktail
+                hour through early reception or after dinner through dancing. The
+                right choice depends on your venue layout, guest count, and how
+                packed your timeline is.
+              </p>
+
+              <h2>Option 1: Open During Cocktail Hour</h2>
+              <p>
+                Cocktail hour is one of the easiest times to start the photo booth.
+                Guests have arrived, they are dressed up, and they are usually
+                looking for something to do while the couple takes portraits or
+                the reception space gets finalized.
+              </p>
+              <p>
+                This works especially well if the booth is near the bar, lounge
+                area, or reception entrance. Guests can grab a drink, take
+                photos, and start the evening with something fun before formal
+                events begin.
+              </p>
+              <p>
+                The only downside is that cocktail hour can go fast. If your venue
+                is moving guests between spaces, or if the booth is tucked away
+                from the main flow, some people may miss it.
+              </p>
+
+              <h2>Option 2: Open After Dinner</h2>
+              <p>
+                Opening after dinner can work really well because guests are
+                settled, speeches are usually done, and people are starting to move
+                around. This is often when the booth line gets busiest.
+              </p>
+              <p>
+                If you want the booth to feel like part of the party, this is a
+                strong option. Guests have more time, groups are easier to gather,
+                and the photos often get funnier as the night goes on.
+              </p>
+              <p>
+                The main thing to watch is timing. If the booth opens too late,
+                older guests or families with kids may leave before using it. If
+                you have a lot of guests who may head out early, consider opening
+                before dinner ends or right after the first dances.
+              </p>
+
+              <h2>Option 3: Keep It Open Through Dancing</h2>
+              <p>
+                A photo booth near the dance floor can add a lot of energy. Guests
+                take a few photos, dance, come back with a different group, and
+                take more. This is when unlimited prints and QR downloads really
+                matter because people tend to use the booth more than once.
+              </p>
+              <p>
+                This timing works best when your booth is easy to see and not
+                hidden in a hallway. If guests have to leave the party completely
+                to find it, usage usually drops.
+              </p>
+
+              <h2>A Strong Three-Hour Booth Timeline</h2>
+              <p>
+                For a typical Bay Area wedding, a good three-hour booth window is
+                cocktail hour through early dancing, or dinner ending through the
+                dance floor.
+              </p>
+              <p>
+                If your package is three hours, I usually would not spend the
+                whole booth time during dinner. Guests are seated, food is being
+                served, and people are less likely to leave the table unless there
+                is a natural break.
+              </p>
+              <p>
+                A strong setup might look like this:
+              </p>
+              <ul>
+                <li>Open the booth near the end of cocktail hour.</li>
+                <li>
+                  Let guests use it before dinner or during the room transition.
+                </li>
+                <li>
+                  Let speeches and formal moments happen without forcing booth
+                  traffic.
+                </li>
+                <li>
+                  Expect the booth to get busy again after dinner and first
+                  dances.
+                </li>
+              </ul>
+
+              <h2>Where Should the Photo Booth Be Placed?</h2>
+              <p>
+                Timing matters, but placement matters just as much. The booth
+                should be close enough that guests notice it, but not so close
+                that it blocks catering, speeches, or the dance floor.
+              </p>
+              <p>
+                Good spots include near the bar, near the reception entrance,
+                beside the dance floor, or in a visible lounge or foyer area.
+                Avoid placing it too far outside the main reception space unless
+                there are signs or the venue naturally sends guests that way.
+              </p>
+
+              <h2>Final Recommendation</h2>
+              <p>
+                If you are not sure, open the photo booth earlier rather than
+                later. Guests look their freshest near the beginning of the night,
+                families are still around, and the booth can help warm up the
+                reception before dancing starts.
+              </p>
+
+              <h2>Essential Reading for Wedding Planning</h2>
+              <p>
+                To make sure your wedding day runs flawlessly, check out our other
+                expert planning guides:
+              </p>
+              <ul>
+                <li>
+                  <strong>Why rent a booth?</strong> Learn the key social and
+                  memory-making benefits in our
+                  <a
+                    href="./blog_1.html"
+                    style="
+                      color: #ff6b6b;
+                      font-weight: 600;
+                      text-decoration: underline;
+                    "
+                    >Wedding Photo Booth Benefits Guide</a
+                  >.
+                </li>
+                <br />
+                <li>
+                  <strong>Compare equipment & quality:</strong> Learn how to spot
+                  professional gear in our guide on
+                  <a
+                    href="./blog_2.html"
+                    style="
+                      color: #ff6b6b;
+                      font-weight: 600;
+                      text-decoration: underline;
+                    "
+                    >How to Choose a Bay Area Photo Booth Vendor</a
+                  >.
+                </li>
+                <br />
+                <li>
+                  <strong>Understand the budget:</strong> See exactly what to
+                  expect in our comprehensive
+                  <a
+                    href="./blog_3.html"
+                    style="
+                      color: #ff6b6b;
+                      font-weight: 600;
+                      text-decoration: underline;
+                    "
+                    >Bay Area Wedding Photo Booth Cost Guide</a
+                  >.
+                </li>
+              </ul>
+
+              <p style="text-align: center; margin-top: 40px; font-style: italic">
+                For Bay Area weddings, Handsome Photobooth includes setup, an
+                attendant, unlimited prints, QR downloads, and a custom template,
+                so the booth can fit naturally into your timeline without adding
+                another thing for you to manage.
+              </p>
+
+              <p style="text-align: center; margin-top: 20px">
+                See our dedicated
+                <a
+                  class="blog-link"
+                  href="https://handsomephotobooth.com/bay-area-wedding-photo-booth.html"
+                  style="font-weight: 700; color: #ff6b6b"
+                  >Bay Area wedding photo booth rental</a
+                >
+                package for pricing, what is included, and reviews from real
+                couples.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container">
+        <div class="footer-content">
+          <div class="footer-nav">
+            <div>
+              <h5 class="gradient">Follow Us!</h5>
+              <ul class="social-list">
+                <li>
+                  <a
+                    href="https://www.instagram.com/handsomephotobooth/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Follow Handsome Photobooth on Instagram"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+                      <defs>
+                        <linearGradient
+                          id="instagram-gradient"
+                          x1="0%"
+                          y1="100%"
+                          x2="100%"
+                          y2="0%"
+                        >
+                          <stop
+                            offset="0%"
+                            style="stop-color: #feda75; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="25%"
+                            style="stop-color: #fa7e1e; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="50%"
+                            style="stop-color: #d62976; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="75%"
+                            style="stop-color: #962fbf; stop-opacity: 1"
+                          />
+                          <stop
+                            offset="100%"
+                            style="stop-color: #4f5bd5; stop-opacity: 1"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <path
+                        fill="url(#instagram-gradient)"
+                        d="M9.9980469 3C6.1390469 3 3 6.1419531 3 10.001953L3 20.001953C3 23.860953 6.1419531 27 10.001953 27L20.001953 27C23.860953 27 27 23.858047 27 19.998047L27 9.9980469C27 6.1390469 23.858047 3 19.998047 3L9.9980469 3 z M 22 7C22.552 7 23 7.448 23 8C23 8.552 22.552 9 22 9C21.448 9 21 8.552 21 8C21 7.448 21.448 7 22 7 z M 15 9C18.309 9 21 11.691 21 15C21 18.309 18.309 21 15 21C11.691 21 9 18.309 9 15C9 11.691 11.691 9 15 9 z M 15 11 A 4 4 0 0 0 11 15 A 4 4 0 0 0 15 19 A 4 4 0 0 0 19 15 A 4 4 0 0 0 15 11 z"
+                      />
+                    </svg>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="copyright">
+            <p>© Copyright 2026 Handsome Photobooth | All Rights Reserved</p>
+          </div>
+        </div>
+      </div>
     </footer>
+
     <script src="../assets/js/swiper.js"></script>
     <script src="../assets/js/script.js"></script>
     <script src="../assets/js/fslightbox.js"></script>
     <script src="../assets/js/share.js"></script>
-</body>
-
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -581,7 +581,7 @@ connect-src 'self'
               <p style="text-align: center; margin-top: 10px;">
                 Planning a wedding? See our dedicated
                 <a href="./bay-area-wedding-photo-booth.html">Bay Area wedding photo booth rental</a>
-                page.
+                page, or learn <a href="./blog/blog_2.html">how to choose a Bay Area photo booth vendor</a>.
               </p>
             </div>
             <br />


### PR DESCRIPTION
- Reset nested <header> elements (main/article/section/aside header) to position: static, fixing the blog editorial header being hijacked by the global "header { position: fixed }" rule, which caused the title to overlap the top nav.
- Give the blog page a permanently solid dark top nav (scoped to direct child only) so the nav is never transparent over the gradient.
- Simplify .blogs-page .blogs-section top padding (160/140/120px) now that the layout no longer needs to compensate for a broken header.
- Restyle blog index header for stronger SEO + brand:
  - H1 "Bay Area Photo Booth Rental Guide for Weddings & Events" with brand cyan-to-magenta gradient text.
  - Gradient eyebrow pill "Bay Area Photo Booth Rental Blog".
  - Intro adds trust signals (since 2022, The Knot Best of Weddings 2024-2026).
- Add internal link from index.html promo blurb to vendor-selection blog post.
- Reformat blog_1/2/3.html and wedding-photo-booth-timeline.html (consistent indentation; no content changes).